### PR TITLE
Fix the detection of `epub:type`-based page markers + Run script tests in headless Chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.2.0",
     "eslint-plugin-import": "^2.3.0",
-    "jest": "^21.1.0",
+    "jest": "21.3.0-beta.3",
     "rimraf": "^2.6.1",
     "standard-version": "^4.2.0",
     "uglify-js": "^3.0.8",

--- a/src/checker/checker-chromium.js
+++ b/src/checker/checker-chromium.js
@@ -4,79 +4,26 @@ const fs = require('fs');
 const path = require('path');
 const pMap = require('p-map');
 const puppeteer = require('puppeteer');
-const axe2ace = require('../report/axe2ace.js');
 const winston = require('winston');
 
-const PATH_TO_AXE = path.join(path.dirname(require.resolve('axe-core')), 'axe.min.js');
-if (!fs.existsSync(PATH_TO_AXE)) {
-  winston.verbose(PATH_TO_AXE);
-  throw new Error('Can’t find aXe');
-}
+const axe2ace = require('../report/axe2ace.js');
+const utils = require('./puppeteer-utils');
 
-const PATH_TO_H5O = path.join(path.dirname(require.resolve('h5o')), 'dist/outliner.min.js');
-if (!fs.existsSync(PATH_TO_H5O)) {
-  winston.verbose(PATH_TO_H5O);
-  throw new Error('Can’t find h5o');
-}
-
-const PATH_TO_AXE_PATCH_GETSELECTOR = path.join(__dirname, '../scripts/axe-patch-getselector.js');
-if (!fs.existsSync(PATH_TO_AXE_PATCH_GETSELECTOR)) {
-  winston.verbose(PATH_TO_AXE_PATCH_GETSELECTOR);
-  throw new Error('Can’t find axe-patch-getselector script');
-}
-
-const PATH_TO_AXE_PATCH_ARIALOOKUPTABLE = path.join(__dirname, '../scripts/axe-patch-arialookuptable.js');
-if (!fs.existsSync(PATH_TO_AXE_PATCH_ARIALOOKUPTABLE)) {
-  winston.verbose(PATH_TO_AXE_PATCH_ARIALOOKUPTABLE);
-  throw new Error('Can’t find axe-patch-arialookuptable script');
-}
-
-const PATH_TO_ACE_AXE = path.join(__dirname, '../scripts/ace-axe.js');
-if (!fs.existsSync(PATH_TO_ACE_AXE)) {
-  winston.verbose(PATH_TO_ACE_AXE);
-  throw new Error('Can’t find ace-axe script');
-}
-
-const PATH_TO_ACE_EXTRACTION = path.join(__dirname, '../scripts/ace-extraction.js');
-if (!fs.existsSync(PATH_TO_ACE_EXTRACTION)) {
-  winston.verbose(PATH_TO_ACE_EXTRACTION);
-  throw new Error('Can’t find ace-extraction script');
-}
+const scripts = [
+  path.resolve(require.resolve('axe-core'), '../axe.min.js'),
+  path.resolve(require.resolve('h5o'), '../dist/outliner.min.js'),
+  require.resolve('../scripts/axe-patch-getselector.js'),
+  require.resolve('../scripts/axe-patch-arialookuptable.js'),
+  require.resolve('../scripts/ace-axe.js'),
+  require.resolve('../scripts/ace-extraction.js'),
+];
 
 async function checkSingle(spineItem, epub, browser) {
   winston.verbose(`- Processing ${spineItem.relpath}`);
   try {
     const page = await browser.newPage();
     await page.goto(spineItem.url);
-    // page.on('console', msg => console.log(msg.text));
-
-    // BEGIN HACK
-    // Used to differentiate original `script` elements from the one
-    // added by Puppeteer.
-    // FIXME remove this hack when GoogleChrome/puppeteer#1179 is fixed
-    await page.$$eval('script', (scripts) => {
-      scripts.forEach(script => script.setAttribute('data-ace-orig', ''));
-    });
-    // END HACK
-    await page.addScriptTag({ path: PATH_TO_AXE });
-    await page.addScriptTag({ path: PATH_TO_AXE_PATCH_GETSELECTOR });
-    await page.addScriptTag({ path: PATH_TO_AXE_PATCH_ARIALOOKUPTABLE });
-    await page.addScriptTag({ path: PATH_TO_H5O });
-    await page.addScriptTag({ path: PATH_TO_ACE_AXE });
-    await page.addScriptTag({ path: PATH_TO_ACE_EXTRACTION });
-    // BEGIN HACK
-    // FIXME remove this hack when GoogleChrome/puppeteer#1179 is fixed
-    await page.$$eval('script', (scripts) => {
-      scripts.forEach(script => {
-        if (script.hasAttribute('data-ace-orig')) {
-          script.removeAttribute('data-ace-orig');
-        } else {
-          script.setAttribute('data-ace', '');
-        }
-      });
-    });
-    // END HACK
-
+    await utils.addScripts(scripts, page);
 
     const results = await page.evaluate(() => new Promise((resolve, reject) => {
         /* eslint-disable */

--- a/src/checker/puppeteer-utils.js
+++ b/src/checker/puppeteer-utils.js
@@ -1,0 +1,32 @@
+'use strict';
+
+async function addScripts(paths, page) {
+  // BEGIN HACK
+  // Used to differentiate original `script` elements from the one
+  // added by Puppeteer.
+  // FIXME remove this hack when GoogleChrome/puppeteer#1179 is fixed
+  await page.$$eval('script', (scripts) => {
+    scripts.forEach(script => script.setAttribute('data-ace-orig', ''));
+  });
+  /* eslint-disable no-restricted-syntax, no-await-in-loop */
+  for (const path of paths) {
+    await page.addScriptTag({ path });
+  }
+  /* eslint-enable no-restricted-syntax, no-await-in-loop */
+  // BEGIN HACK
+  // FIXME remove this hack when GoogleChrome/puppeteer#1179 is fixed
+  await page.$$eval('script', (scripts) => {
+    scripts.forEach((script) => {
+      if (script.hasAttribute('data-ace-orig')) {
+        script.removeAttribute('data-ace-orig');
+      } else {
+        script.setAttribute('data-ace', '');
+      }
+    });
+  });
+  // END HACK
+}
+
+module.exports = {
+  addScripts,
+};

--- a/src/scripts/ace-extraction.js
+++ b/src/scripts/ace-extraction.js
@@ -242,5 +242,5 @@ ace.hasMathML = function() {
 }
 
 ace.hasPageBreaks = function() {
-  return document.querySelectorAll('[epub\\:type~="pagebreak"], [role~="doc-pagebreak"]').length > 0;
+  return document.querySelectorAll('[*|type~="pagebreak"], [role~="doc-pagebreak"]').length > 0;
 }

--- a/src/scripts/ace-extraction.test.js
+++ b/src/scripts/ace-extraction.test.js
@@ -321,7 +321,7 @@ describe('finding pagebreaks', () => {
     expect(results).toBe(false);
   });
 
-  test.skip('epub:type break', async () => {
+  test('epub:type break', async () => {
     const results = await run('hasPageBreaks', '<span epub:type="pagebreak" />');
     expect(results).toBe(true);
   });

--- a/src/scripts/ace-extraction.test.js
+++ b/src/scripts/ace-extraction.test.js
@@ -1,35 +1,46 @@
 /**
- * @jest-environment jsdom
+ * @jest-environment ./tests/jest-env-puppeteer.js
  */
  /* eslint-env browser, jest */
 
 'use strict';
 
-require('./ace-extraction');
+const $ = require('../../tests/browser-test-utils');
 
-// Mock function defined in other modules
-window.daisy.epub = {
-  createCFI: jest.fn(),
-};
-const mockH5O = jest.fn();
-mockH5O.mockReturnValue({
-  asHTML: jest.fn(),
-});
-window.HTML5Outline = mockH5O;
-
-const ace = window.daisy.ace;
-const epub = window.daisy.epub;
-
-beforeEach(() => {
-  epub.createCFI.mockReturnValue('42');
-});
-afterEach(() => {
-  epub.createCFI.mockClear();
+beforeAll(async () => {
+  await $.loadXHTMLPage();
+  await $.injectScripts([require.resolve('./ace-extraction.js')]);
+  await $.injectJestMock();
+  await global.page.evaluate(() => {
+    const mockH5O = window.mock.fn();
+    mockH5O.mockReturnValue({
+      asHTML: window.mock.fn(),
+    });
+    window.HTML5Outline = mockH5O;
+    window.daisy.epub = {
+      createCFI: window.mock.fn(),
+    };
+    window.daisy.epub.createCFI.mockReturnValue('42');
+  });
 });
 
-test('createReport', () => {
-  const report = {};
-  ace.createReport(report);
+afterAll(async () => {
+  await $.closePage();
+});
+
+async function run(name, markup) {
+  return global.page.evaluate(($name, $markup) => {
+    document.body.innerHTML = $markup;
+    return window.ace[$name]();
+  }, name, markup);
+}
+
+test('createReport', async () => {
+  const report = await global.page.evaluate(() => {
+    const ret = {};
+    window.ace.createReport(ret);
+    return ret;
+  });
   expect(report.outlines).toBeDefined();
   expect(report.data).toBeDefined();
   expect(report.data).toEqual({});
@@ -39,40 +50,32 @@ test('createReport', () => {
 });
 
 describe('extracting audio', () => {
-  test('simple audio', () => {
-    const html = `
-    <audio src="foo.mp3" id="foo" controls=""></audio>`;
-    document.body.innerHTML = html;
-    const results = ace.getAudios();
+  test('simple audio', async () => {
+    const results = await run('getAudios', '<audio src="foo.mp3" id="foo" controls=""></audio>');
     expect(results.length).toBe(1);
-    expect(results[0].html).toBe(html.trim());
+    expect(results[0].html).toBeDefined();
     expect(results[0].id).toBe('foo');
     expect(results[0].controls).toBeTruthy();
     expect(results[0].tracks).toEqual([]);
   });
 
-  test('audio with no id', () => {
-    document.body.innerHTML = `
-    <audio src="foo.mp3"/>`;
-    const results = ace.getAudios();
+  test('audio with no id', async () => {
+    const results = await run('getAudios', '<audio src="foo.mp3"/>');
     expect(results.length).toBe(1);
     expect(results[0].id).toBeUndefined();
   });
 
-  test('audio with no controls', () => {
-    document.body.innerHTML = `
-    <audio src="foo.webm"/>`;
-    const results = ace.getAudios();
+  test('audio with no controls', async () => {
+    const results = await run('getAudios', '<audio src="foo.webm"/>');
     expect(results.length).toBe(1);
     expect(results[0].controls).toBe(false);
   });
 
-  test('audio with sources', () => {
-    document.body.innerHTML = `
+  test('audio with sources', async () => {
+    const results = await run('getAudios', `
     <audio>
       <source src="audio.wav" type="audio/wav"/>
-    </audio>`;
-    const results = ace.getAudios();
+    </audio>`);
     expect(results.length).toBe(1);
     expect(results[0].src).toBeDefined();
     expect(Array.isArray(results[0].src)).toBeTruthy();
@@ -83,13 +86,12 @@ describe('extracting audio', () => {
     });
   });
 
-  test('audio with tracks', () => {
-    document.body.innerHTML = `
+  test('audio with tracks', async () => {
+    const results = await run('getAudios', `
     <audio src="foo.mp3">
-      <track kind="subtitles" src="foo.en.vtt" srclang="en" label="English">
-      <track kind="subtitles" src="foo.fr.vtt" srclang="fr" label="Français">
-    </audio>`;
-    const results = ace.getAudios();
+      <track kind="subtitles" src="foo.en.vtt" srclang="en" label="English"/>
+      <track kind="subtitles" src="foo.fr.vtt" srclang="fr" label="Français"/>
+    </audio>`);
     expect(results.length).toBe(1);
     expect(results[0].tracks).toBeDefined();
     expect(results[0].tracks.length).toBe(2);
@@ -103,68 +105,51 @@ describe('extracting audio', () => {
 });
 
 describe('extracting canvases', () => {
-  test('simple canva', () => {
-    document.body.innerHTML = `
-    <canvas id="foo"></canvas>
-    `;
-    const results = ace.getCanvases();
+  test('simple canva', async () => {
+    const results = await run('getCanvases', '<canvas id="foo"></canvas>');
     expect(results.length).toBe(1);
     expect(results[0].html).toBeUndefined();
     expect(results[0].id).toEqual('foo');
   });
 
-  test('canvas with no id', () => {
-    document.body.innerHTML = `
-    <canvas></canvas>`;
-    const results = ace.getCanvases();
+  test('canvas with no id', async () => {
+    const results = await run('getCanvases', '<canvas></canvas>');
     expect(results.length).toBe(1);
     expect(results[0].id).toBeUndefined();
   });
 });
 
 describe('extracting embeds', () => {
-  test('simple embed', () => {
-    document.body.innerHTML = `
-    <embed type="video/quicktime" src="movie.mov" id="foo"></embed>
-    `;
-    const results = ace.getEmbeds();
+  test('simple embed', async () => {
+    const results = await run('getEmbeds', '<embed type="video/quicktime" src="movie.mov" id="foo"></embed>');
     expect(results.length).toBe(1);
     expect(results[0].html).toBeUndefined();
     expect(results[0].src).toEqual('movie.mov');
     expect(results[0].id).toEqual('foo');
   });
 
-  test('embed with no id', () => {
-    document.body.innerHTML = `
-    <embed src="movie.mov"/>`;
-    const results = ace.getEmbeds();
+  test('embed with no id', async () => {
+    const results = await run('getEmbeds', '<embed src="movie.mov"/>');
     expect(results.length).toBe(1);
     expect(results[0].id).toBeUndefined();
   });
 
-  test('embed with no src', () => {
-    document.body.innerHTML = `
-    <embed/>`;
-    const results = ace.getEmbeds();
+  test('embed with no src', async () => {
+    const results = await run('getEmbeds', '<embed/>');
     expect(results.length).toBe(1);
     expect(results[0].src).toBeUndefined();
   });
 
-  test('embed with no type', () => {
-    document.body.innerHTML = `
-    <embed src="movie.mov"/>`;
-    const results = ace.getEmbeds();
+  test('embed with no type', async () => {
+    const results = await run('getEmbeds', '<embed src="movie.mov"/>');
     expect(results.length).toBe(1);
     expect(results[0].type).toBeUndefined();
   });
 });
 
 describe('extracting headings', () => {
-  test('simple h1', () => {
-    document.body.innerHTML = `
-    <h1>title 1</h1>
-    `;
-    const results = ace.getHeadings();
+  test('simple h1', async () => {
+    const results = await run('getHeadings', '<h1>title 1</h1>');
     expect(results.length).toBe(1);
     expect(results[0].html).toBe('title 1');
     expect(results[0].level).toBe(1);
@@ -172,53 +157,40 @@ describe('extracting headings', () => {
 });
 
 describe('extracting iframes', () => {
-  test('simple iframe', () => {
-    document.body.innerHTML = `
-    <iframe src="test.html" id="foo"></iframe>
-    `;
-    const results = ace.getIframes();
+  test('simple iframe', async () => {
+    const results = await run('getIframes', '<iframe src="test.html" id="foo"></iframe>');
     expect(results.length).toBe(1);
     expect(results[0].html).toBeUndefined();
     expect(results[0].src).toEqual('test.html');
     expect(results[0].id).toEqual('foo');
   });
 
-  test('iframe with no id', () => {
-    document.body.innerHTML = `
-    <iframe src="test.html"/>`;
-    const results = ace.getIframes();
+  test('iframe with no id', async () => {
+    const results = await run('getIframes', '<iframe src="test.html"/>');
     expect(results.length).toBe(1);
     expect(results[0].id).toBeUndefined();
   });
 });
 
 describe('extracting maps', () => {
-  test('simple map', () => {
-    document.body.innerHTML = `
-    <map name="bar" id="foo"></map>
-    `;
-    const results = ace.getMaps();
+  test('simple map', async () => {
+    const results = await run('getMaps', '<map name="bar" id="foo"></map>');
     expect(results.length).toBe(1);
     expect(results[0].html).toBeUndefined();
     expect(results[0].name).toEqual('bar');
     expect(results[0].id).toEqual('foo');
   });
 
-  test('map with no id', () => {
-    document.body.innerHTML = `
-    <map name="foo"/>`;
-    const results = ace.getMaps();
+  test('map with no id', async () => {
+    const results = await run('getMaps', '<map name="foo"/>');
     expect(results.length).toBe(1);
     expect(results[0].id).toBeUndefined();
   });
 });
 
 describe('extracting objects', () => {
-  test('simple object', () => {
-    document.body.innerHTML = `
-    <object data="movie.swf" type="application/x-shockwave-flash" id="foo"></object>
-    `;
-    const results = ace.getObjects();
+  test('simple object', async () => {
+    const results = await run('getObjects', '<object data="movie.swf" type="application/x-shockwave-flash" id="foo"></object>');
     expect(results.length).toBe(1);
     expect(results[0].html).toBeUndefined();
     expect(results[0].data).toEqual('movie.swf');
@@ -226,37 +198,28 @@ describe('extracting objects', () => {
     expect(results[0].type).toEqual('application/x-shockwave-flash');
   });
 
-  test('object with no id', () => {
-    document.body.innerHTML = `
-    <object data="movie.swf"/>`;
-    const results = ace.getObjects();
+  test('object with no id', async () => {
+    const results = await run('getObjects', '<object data="movie.swf"/>');
     expect(results.length).toBe(1);
     expect(results[0].id).toBeUndefined();
   });
 
-  test('object with no data`', () => {
-    document.body.innerHTML = `
-    <object id="foo"/>`;
-    const results = ace.getObjects();
+  test('object with no data`', async () => {
+    const results = await run('getObjects', '<object id="foo"/>');
     expect(results.length).toBe(1);
     expect(results[0].data).toBeUndefined();
   });
 
-  test('object with no type', () => {
-    document.body.innerHTML = `
-    <object data="movie.swf"/>`;
-    const results = ace.getObjects();
+  test('object with no type', async () => {
+    const results = await run('getObjects', '<object data="movie.swf"/>');
     expect(results.length).toBe(1);
     expect(results[0].type).toBeUndefined();
   });
 });
 
 describe('extracting scripts', () => {
-  test('simple script', () => {
-    document.body.innerHTML = `
-    <script src="script.js" id="foo"></script>
-    `;
-    const results = ace.getScripts();
+  test('simple script', async () => {
+    const results = await run('getScripts', '<script src="script.js" id="foo"></script>');
     expect(results.length).toBe(1);
     expect(results[0].html).toBeUndefined();
     expect(results[0].src).toEqual('script.js');
@@ -264,68 +227,54 @@ describe('extracting scripts', () => {
     expect(results[0].type).toEqual('text/javascript');
   });
 
-  test('script with no id', () => {
-    document.body.innerHTML = `
-    <script src="script.js"/>`;
-    const results = ace.getScripts();
+  test('script with no id', async () => {
+    const results = await run('getScripts', '<script src="script.js"/>');
     expect(results.length).toBe(1);
     expect(results[0].id).toBeUndefined();
   });
 
-  test('script with no src', () => {
-    document.body.innerHTML = `
-    <script/>`;
-    const results = ace.getScripts();
+  test('script with no src', async () => {
+    const results = await run('getScripts', '<script/>');
     expect(results.length).toBe(1);
     expect(results[0].src).toBeUndefined();
   });
 
-  test('script with explicit type', () => {
-    document.body.innerHTML = `
-    <script type="application/ld+json"/>`;
-    const results = ace.getScripts();
+  test('script with explicit type', async () => {
+    const results = await run('getScripts', '<script type="application/ld+json"/>');
     expect(results.length).toBe(1);
     expect(results[0].type).toEqual('application/ld+json');
   });
 });
 
 describe('extracting video', () => {
-  test('simple video', () => {
-    const html = `
-    <video src="foo.webm" id="foo" controls=""></video>`;
-    document.body.innerHTML = html;
-    const results = ace.getVideos();
+  test('simple video', async () => {
+    const results = await run('getVideos', '<video src="foo.webm" id="foo" controls=""></video>');
     expect(results.length).toBe(1);
-    expect(results[0].html).toBe(html.trim());
+    expect(results[0].html).toBeDefined();
     expect(results[0].controls).toBeTruthy();
     expect(results[0].src).toEqual('foo.webm');
     expect(results[0].id).toEqual('foo');
     expect(results[0].tracks).toEqual([]);
   });
 
-  test('video with no id', () => {
-    document.body.innerHTML = `
-    <video src="foo.webm"/>`;
-    const results = ace.getVideos();
+  test('video with no id', async () => {
+    const results = await run('getVideos', '<video src="foo.webm"/>');
     expect(results.length).toBe(1);
     expect(results[0].id).toBeUndefined();
   });
 
-  test('video with no controls', () => {
-    document.body.innerHTML = `
-    <video src="foo.webm"/>`;
-    const results = ace.getVideos();
+  test('video with no controls', async () => {
+    const results = await run('getVideos', '<video src="foo.webm"/>');
     expect(results.length).toBe(1);
     expect(results[0].controls).toBe(false);
   });
 
-  test('video with tracks', () => {
-    document.body.innerHTML = `
+  test('video with tracks', async () => {
+    const results = await run('getVideos', `
     <video src="foo.webm">
-      <track kind="subtitles" src="foo.en.vtt" srclang="en" label="English">
-      <track kind="subtitles" src="foo.fr.vtt" srclang="fr" label="Français">
-    </video>`;
-    const results = ace.getVideos();
+      <track kind="subtitles" src="foo.en.vtt" srclang="en" label="English"/>
+      <track kind="subtitles" src="foo.fr.vtt" srclang="fr" label="Français"/>
+    </video>`);
     expect(results.length).toBe(1);
     expect(results[0].tracks).toBeDefined();
     expect(results[0].tracks.length).toEqual(2);
@@ -337,13 +286,12 @@ describe('extracting video', () => {
     });
   });
 
-  test('video with sources', () => {
-    document.body.innerHTML = `
+  test('video with sources', async () => {
+    const results = await run('getVideos', `
     <video>
       <source src="video.webm" type="video/webm"/>
       <source src="video.mp4" type="video/mp4"/>
-    </video>`;
-    const results = ace.getVideos();
+    </video>`);
     expect(results.length).toBe(1);
     expect(results[0].src).toBeDefined();
     expect(Array.isArray(results[0].src)).toBeTruthy();
@@ -356,41 +304,35 @@ describe('extracting video', () => {
 });
 
 describe('finding mathml', () => {
-  test('no math', () => {
-    document.body.innerHTML = `
-    <p>foo</p>`;
-    expect(ace.hasMathML()).toBe(false);
+  test('no math', async () => {
+    const results = await run('hasMathML', '<p>foo</p>');
+    expect(results).toBe(false);
   });
 
-  test('with math', () => {
-    document.body.innerHTML = `
-    <math><mi>x</mi></math>`;
-    expect(ace.hasMathML()).toBe(true);
+  test('with math', async () => {
+    const results = await run('hasMathML', '<math><mi>x</mi></math>');
+    expect(results).toBe(true);
   });
 });
 
 describe('finding pagebreaks', () => {
-  test('no breaks', () => {
-    document.body.innerHTML = `
-    <p>foo</p>`;
-    expect(ace.hasPageBreaks()).toBe(false);
+  test('no breaks', async () => {
+    const results = await run('hasPageBreaks', '<p>foo</p>');
+    expect(results).toBe(false);
   });
 
-  test('epub:type break', () => {
-    document.body.innerHTML = `
-    <span epub:type="pagebreak">`;
-    expect(ace.hasPageBreaks()).toBe(true);
+  test.skip('epub:type break', async () => {
+    const results = await run('hasPageBreaks', '<span epub:type="pagebreak" />');
+    expect(results).toBe(true);
   });
 
-  test('ARIA role break', () => {
-    document.body.innerHTML = `
-    <span role="doc-pagebreak">`;
-    expect(ace.hasPageBreaks()).toBe(true);
+  test('ARIA role break', async () => {
+    const results = await run('hasPageBreaks', '<span role="doc-pagebreak"/>');
+    expect(results).toBe(true);
   });
 
-  test('pagebreak role among other values', () => {
-    document.body.innerHTML = `
-    <span role="foo doc-pagebreak bar">`;
-    expect(ace.hasPageBreaks()).toBe(true);
+  test('pagebreak role among other values', async () => {
+    const results = await run('hasPageBreaks', '<span role="foo doc-pagebreak bar"/>');
+    expect(results).toBe(true);
   });
 });

--- a/tests/__tests__/regression.test.js
+++ b/tests/__tests__/regression.test.js
@@ -50,3 +50,9 @@ test('issue #57: Failed to execute \'matches\' on \'Element\': \'m:annotation-xm
   const report = await ace('../data/issue-57');
   expect(report['earl:result']['earl:outcome']).toEqual('pass');
 });
+
+test('issue #85: failed to detect page markers from `epub:type`', async () => {
+  const report = await ace('../data/issue-85');
+  expect(report['earl:result']['earl:outcome']).toEqual('pass');
+  expect(report.properties.hasPageBreaks).toBe(true);
+});

--- a/tests/browser-test-utils.js
+++ b/tests/browser-test-utils.js
@@ -1,0 +1,54 @@
+/* eslint-env browser, jest */
+
+'use strict';
+
+const paths = require('path');
+const utils = require('../src/checker/puppeteer-utils');
+
+async function closePage() {
+  await global.page.close();
+}
+
+async function injectJestMock() {
+  await utils.addScripts(
+    [paths.resolve(require.resolve('jest-mock'), '../../build-es5/index.js')], global.page);
+  await global.page.evaluate(() => {
+    window.mock = new window['jest-mock'].ModuleMocker();
+  });
+}
+
+async function injectScripts(scripts) {
+  await utils.addScripts(scripts, global.page);
+}
+
+async function insertBody(markup) {
+  await global.page.evaluate((innerBody) => {
+    document.body.innerHTML = innerBody;
+  }, markup);
+}
+
+async function loadXHTMLPage() {
+  global.page = await global.browser.newPage();
+  await global.page.goto(`data:application/xhtml+xml,<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+  <head>
+    <title></title>
+  </head>
+  <body>
+  </body>
+</html>`);
+}
+
+function redirectConsole() {
+  global.page.on('console', msg => console.log(msg.text));
+}
+
+
+module.exports = {
+  closePage,
+  injectJestMock,
+  injectScripts,
+  insertBody,
+  loadXHTMLPage,
+  redirectConsole,
+};

--- a/tests/data/issue-85/EPUB/content_001.xhtml
+++ b/tests/data/issue-85/EPUB/content_001.xhtml
@@ -1,0 +1,10 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal EPUB</title>
+</head>
+<body>
+<h1>Loomings</h1>
+<p>Call me Ishmael.</p>
+<span id="p1" epub:type="pagebreak" aria-label="page 1"/>
+</body>
+</html>

--- a/tests/data/issue-85/EPUB/nav.xhtml
+++ b/tests/data/issue-85/EPUB/nav.xhtml
@@ -1,0 +1,17 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal Nav</title>
+</head>
+<body>
+<nav epub:type="toc">
+<ol>
+<li><a href="content_001.xhtml">content 001</a></li>
+</ol>
+</nav>
+<nav epub:type="page-list">
+<ol>
+<li><a href="content_001.xhtml#p1">page 1</a></li>
+</ol>
+</nav>
+</body>
+</html>

--- a/tests/data/issue-85/EPUB/package.opf
+++ b/tests/data/issue-85/EPUB/package.opf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="uid">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="uid">NOID</dc:identifier>
+  <dc:source>https://example.com</dc:source>
+  <meta property="dcterms:modified">2017-01-01T00:00:01Z</meta>
+  <meta property="schema:accessibilityFeature">structuralNavigation</meta>
+  <meta property="schema:accessibilitySummary">everything OK!</meta>
+  <meta property="schema:accessibilityHazard">noFlashingHazard</meta>
+  <meta property="schema:accessibilityHazard">noSoundHazard</meta>
+  <meta property="schema:accessibilityHazard">noMotionSimulationHazard</meta>
+  <meta property="schema:accessMode">textual</meta>
+  <meta property="schema:accessModeSufficient">textual</meta>
+</metadata>
+<manifest>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/tests/data/issue-85/META-INF/container.xml
+++ b/tests/data/issue-85/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   <rootfiles>
+      <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+   </rootfiles>
+</container>

--- a/tests/data/issue-85/mimetype
+++ b/tests/data/issue-85/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/tests/jest-env-puppeteer.js
+++ b/tests/jest-env-puppeteer.js
@@ -1,0 +1,26 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+'use strict';
+
+const NodeEnvironment = require('jest-environment-node');
+const puppeteer = require('puppeteer');
+
+class HeadlessChromeEnvironment extends NodeEnvironment {
+
+  setup() {
+    return super.setup().then(() =>
+      puppeteer.launch().then((browser) => {
+        this.global.browser = browser;
+      }));
+  }
+
+  teardown() {
+    return this.global.browser.close().then(() => super.teardown());
+  }
+
+  runScript(script) {
+    return super.runScript(script);
+  }
+}
+
+module.exports = HeadlessChromeEnvironment;

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,7 +320,7 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.0.0, babel-core@^6.26.0:
+babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -458,6 +458,13 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
+babel-jest@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-21.3.0-beta.3.tgz#fddb77d150555c4df9014af3a3fe290839d264a9"
+  dependencies:
+    babel-plugin-istanbul "^4.1.5"
+    babel-preset-jest "21.3.0-beta.3"
+
 babel-jest@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-21.2.0.tgz#2ce059519a9374a2c46f2455b6fbef5ad75d863e"
@@ -477,13 +484,17 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-istanbul@^4.0.0:
+babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
   dependencies:
     find-up "^2.1.0"
     istanbul-lib-instrument "^1.7.5"
     test-exclude "^4.1.1"
+
+babel-plugin-jest-hoist@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.3.0-beta.3.tgz#a9c854fa0567f8000d66c687e2ad68727af1e608"
 
 babel-plugin-jest-hoist@^21.2.0:
   version "21.2.0"
@@ -744,6 +755,13 @@ babel-preset-env@^1.6.0:
     browserslist "^2.1.2"
     invariant "^2.2.2"
     semver "^5.3.0"
+
+babel-preset-jest@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-21.3.0-beta.3.tgz#baa7a290f939327c14548eaaf479ded6a73ee755"
+  dependencies:
+    babel-plugin-jest-hoist "21.3.0-beta.3"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-preset-jest@^21.2.0:
   version "21.2.0"
@@ -1468,6 +1486,12 @@ debug@2.6.9, debug@^2.1.1, debug@^2.1.2, debug@^2.2.0, debug@^2.4.1, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1533,6 +1557,10 @@ detect-indent@^4.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   dependencies:
     repeating "^2.0.0"
+
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
 
 dicer@0.2.5:
   version "0.2.5"
@@ -1888,15 +1916,15 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expect@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-21.2.1.tgz#003ac2ac7005c3c29e73b38a272d4afadd6d1d7b"
+expect@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-21.3.0-beta.3.tgz#51f609163ac0d5b82ae283635dc8d2d823b82a5b"
   dependencies:
     ansi-styles "^3.2.0"
-    jest-diff "^21.2.1"
-    jest-get-type "^21.2.0"
-    jest-matcher-utils "^21.2.1"
-    jest-message-util "^21.2.1"
+    jest-diff "21.3.0-beta.3"
+    jest-get-type "21.3.0-beta.3"
+    jest-matcher-utils "21.3.0-beta.3"
+    jest-message-util "21.3.0-beta.3"
     jest-regex-util "^21.2.0"
 
 express-easy-zip@^1.1.4:
@@ -2827,33 +2855,33 @@ isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-api@^1.1.1:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.1.14.tgz#25bc5701f7c680c0ffff913de46e3619a3a6e680"
+istanbul-api@^1.1.14:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.2.1.tgz#0c60a0515eb11c7d65c6b50bba2c6e999acd8620"
   dependencies:
     async "^2.1.4"
     fileset "^2.0.2"
     istanbul-lib-coverage "^1.1.1"
-    istanbul-lib-hook "^1.0.7"
-    istanbul-lib-instrument "^1.8.0"
-    istanbul-lib-report "^1.1.1"
-    istanbul-lib-source-maps "^1.2.1"
-    istanbul-reports "^1.1.2"
+    istanbul-lib-hook "^1.1.0"
+    istanbul-lib-instrument "^1.9.1"
+    istanbul-lib-report "^1.1.2"
+    istanbul-lib-source-maps "^1.2.2"
+    istanbul-reports "^1.1.3"
     js-yaml "^3.7.0"
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.1.1:
+istanbul-lib-coverage@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
 
-istanbul-lib-hook@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz#dd6607f03076578fe7d6f2a630cf143b49bacddc"
+istanbul-lib-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.5, istanbul-lib-instrument@^1.8.0:
+istanbul-lib-instrument@^1.7.5, istanbul-lib-instrument@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz#66f6c9421cc9ec4704f76f2db084ba9078a2b532"
   dependencies:
@@ -2865,16 +2893,28 @@ istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.5, istanbul-lib-ins
     istanbul-lib-coverage "^1.1.1"
     semver "^5.3.0"
 
-istanbul-lib-report@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#f0e55f56655ffa34222080b7a0cd4760e1405fc9"
+istanbul-lib-instrument@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz#250b30b3531e5d3251299fdd64b0b2c9db6b558e"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.1.1"
+    semver "^5.3.0"
+
+istanbul-lib-report@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz#922be27c13b9511b979bd1587359f69798c1d425"
   dependencies:
     istanbul-lib-coverage "^1.1.1"
     mkdirp "^0.5.1"
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.1:
+istanbul-lib-source-maps@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz#a6fe1acba8ce08eebc638e572e294d267008aa0c"
   dependencies:
@@ -2884,9 +2924,19 @@ istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.1:
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.2.tgz#0fb2e3f6aa9922bd3ce45d05d8ab4d5e8e07bd4f"
+istanbul-lib-source-maps@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz#750578602435f28a0c04ee6d7d9e0f2960e62c1c"
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.1.1"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+istanbul-reports@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
   dependencies:
     handlebars "^4.0.3"
 
@@ -2896,33 +2946,34 @@ jest-changed-files@^21.2.0:
   dependencies:
     throat "^4.0.0"
 
-jest-cli@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-21.2.1.tgz#9c528b6629d651911138d228bdb033c157ec8c00"
+jest-cli@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-21.3.0-beta.3.tgz#e54e701911315bfafbe6342488d79e0ba1c7e802"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
     glob "^7.1.2"
     graceful-fs "^4.1.11"
     is-ci "^1.0.10"
-    istanbul-api "^1.1.1"
-    istanbul-lib-coverage "^1.0.1"
-    istanbul-lib-instrument "^1.4.2"
-    istanbul-lib-source-maps "^1.1.0"
+    istanbul-api "^1.1.14"
+    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-instrument "^1.8.0"
+    istanbul-lib-source-maps "^1.2.1"
     jest-changed-files "^21.2.0"
-    jest-config "^21.2.1"
-    jest-environment-jsdom "^21.2.1"
-    jest-haste-map "^21.2.0"
-    jest-message-util "^21.2.1"
+    jest-config "21.3.0-beta.3"
+    jest-environment-jsdom "21.3.0-beta.3"
+    jest-haste-map "21.3.0-beta.3"
+    jest-message-util "21.3.0-beta.3"
     jest-regex-util "^21.2.0"
     jest-resolve-dependencies "^21.2.0"
-    jest-runner "^21.2.1"
-    jest-runtime "^21.2.1"
-    jest-snapshot "^21.2.1"
-    jest-util "^21.2.1"
+    jest-runner "21.3.0-beta.3"
+    jest-runtime "21.3.0-beta.3"
+    jest-snapshot "21.3.0-beta.3"
+    jest-util "21.3.0-beta.3"
     micromatch "^2.3.11"
-    node-notifier "^5.0.2"
+    node-notifier "^5.1.2"
     pify "^3.0.0"
+    rimraf "^2.5.4"
     slash "^1.0.0"
     string-length "^2.0.0"
     strip-ansi "^4.0.0"
@@ -2930,97 +2981,101 @@ jest-cli@^21.2.1:
     worker-farm "^1.3.1"
     yargs "^9.0.0"
 
-jest-config@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-21.2.1.tgz#c7586c79ead0bcc1f38c401e55f964f13bf2a480"
+jest-config@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-21.3.0-beta.3.tgz#491285a526d8f40e217f1ea9c47c5199611f8a23"
   dependencies:
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^21.2.1"
-    jest-environment-node "^21.2.1"
-    jest-get-type "^21.2.0"
-    jest-jasmine2 "^21.2.1"
+    jest-environment-jsdom "21.3.0-beta.3"
+    jest-environment-node "21.3.0-beta.3"
+    jest-get-type "21.3.0-beta.3"
+    jest-jasmine2 "21.3.0-beta.3"
     jest-regex-util "^21.2.0"
-    jest-resolve "^21.2.0"
-    jest-util "^21.2.1"
-    jest-validate "^21.2.1"
-    pretty-format "^21.2.1"
+    jest-resolve "21.3.0-beta.3"
+    jest-util "21.3.0-beta.3"
+    jest-validate "21.3.0-beta.3"
+    pretty-format "21.3.0-beta.3"
 
-jest-diff@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-21.2.1.tgz#46cccb6cab2d02ce98bc314011764bb95b065b4f"
+jest-diff@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-21.3.0-beta.3.tgz#8b18c75e08ef9ea27ce0cff54e7155804201623e"
   dependencies:
     chalk "^2.0.1"
     diff "^3.2.0"
-    jest-get-type "^21.2.0"
-    pretty-format "^21.2.1"
+    jest-get-type "21.3.0-beta.3"
+    pretty-format "21.3.0-beta.3"
 
-jest-docblock@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
-
-jest-environment-jsdom@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz#38d9980c8259b2a608ec232deee6289a60d9d5b4"
+jest-docblock@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.3.0-beta.3.tgz#f4db6404ceceb82bdb165928344bcb95d8f45a52"
   dependencies:
-    jest-mock "^21.2.0"
-    jest-util "^21.2.1"
+    detect-newline "^2.1.0"
+
+jest-environment-jsdom@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-21.3.0-beta.3.tgz#b147bd5f73c2c8f0c7d3f4a5296e2f842a95b993"
+  dependencies:
+    jest-mock "21.3.0-beta.3"
+    jest-util "21.3.0-beta.3"
     jsdom "^9.12.0"
 
-jest-environment-node@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-21.2.1.tgz#98c67df5663c7fbe20f6e792ac2272c740d3b8c8"
+jest-environment-node@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-21.3.0-beta.3.tgz#5632843fb4c40d1daafadaf396a15cdb92cd47c6"
   dependencies:
-    jest-mock "^21.2.0"
-    jest-util "^21.2.1"
+    jest-mock "21.3.0-beta.3"
+    jest-util "21.3.0-beta.3"
 
-jest-get-type@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
+jest-get-type@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.3.0-beta.3.tgz#3705a95fbcb7117024d140346a6880059f7ae26d"
 
-jest-haste-map@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-21.2.0.tgz#1363f0a8bb4338f24f001806571eff7a4b2ff3d8"
+jest-haste-map@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-21.3.0-beta.3.tgz#c0676c675958c188df933820022c9db18230091f"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-docblock "^21.2.0"
+    jest-docblock "21.3.0-beta.3"
     micromatch "^2.3.11"
     sane "^2.0.0"
     worker-farm "^1.3.1"
 
-jest-jasmine2@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz#9cc6fc108accfa97efebce10c4308548a4ea7592"
+jest-jasmine2@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-21.3.0-beta.3.tgz#7c9f52f46a9265172e73e2addcdab60b05f63058"
   dependencies:
     chalk "^2.0.1"
-    expect "^21.2.1"
+    expect "21.3.0-beta.3"
     graceful-fs "^4.1.11"
-    jest-diff "^21.2.1"
-    jest-matcher-utils "^21.2.1"
-    jest-message-util "^21.2.1"
-    jest-snapshot "^21.2.1"
+    jest-diff "21.3.0-beta.3"
+    jest-matcher-utils "21.3.0-beta.3"
+    jest-message-util "21.3.0-beta.3"
+    jest-snapshot "21.3.0-beta.3"
     p-cancelable "^0.3.0"
+    source-map-support "^0.5.0"
 
-jest-matcher-utils@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz#72c826eaba41a093ac2b4565f865eb8475de0f64"
+jest-matcher-utils@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.3.0-beta.3.tgz#a7be2b30a08946d50bbac0011da04a96d9adb862"
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^21.2.0"
-    pretty-format "^21.2.1"
+    jest-get-type "21.3.0-beta.3"
+    pretty-format "21.3.0-beta.3"
 
-jest-message-util@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-21.2.1.tgz#bfe5d4692c84c827d1dcf41823795558f0a1acbe"
+jest-message-util@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-21.3.0-beta.3.tgz#e3c893bb5ed9041f125be53b71185301343aeae7"
   dependencies:
     chalk "^2.0.1"
     micromatch "^2.3.11"
     slash "^1.0.0"
+    stack-utils "^1.0.1"
 
-jest-mock@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-21.2.0.tgz#7eb0770e7317968165f61ea2a7281131534b3c0f"
+jest-mock@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-21.3.0-beta.3.tgz#7aaa73222541b08612a0d202fcd60786cf863bf2"
 
 jest-regex-util@^21.2.0:
   version "21.2.0"
@@ -3032,44 +3087,42 @@ jest-resolve-dependencies@^21.2.0:
   dependencies:
     jest-regex-util "^21.2.0"
 
-jest-resolve@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-21.2.0.tgz#068913ad2ba6a20218e5fd32471f3874005de3a6"
+jest-resolve@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-21.3.0-beta.3.tgz#725c524e908bfbce044823ae64fcc8a746d9b181"
   dependencies:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
-    is-builtin-module "^1.0.0"
 
-jest-runner@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-21.2.1.tgz#194732e3e518bfb3d7cbfc0fd5871246c7e1a467"
+jest-runner@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-21.3.0-beta.3.tgz#a309ba58e8fc16040992d0122ce224e837b936ef"
   dependencies:
-    jest-config "^21.2.1"
-    jest-docblock "^21.2.0"
-    jest-haste-map "^21.2.0"
-    jest-jasmine2 "^21.2.1"
-    jest-message-util "^21.2.1"
-    jest-runtime "^21.2.1"
-    jest-util "^21.2.1"
+    jest-config "21.3.0-beta.3"
+    jest-docblock "21.3.0-beta.3"
+    jest-haste-map "21.3.0-beta.3"
+    jest-jasmine2 "21.3.0-beta.3"
+    jest-message-util "21.3.0-beta.3"
+    jest-runtime "21.3.0-beta.3"
+    jest-util "21.3.0-beta.3"
     pify "^3.0.0"
     throat "^4.0.0"
     worker-farm "^1.3.1"
 
-jest-runtime@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-21.2.1.tgz#99dce15309c670442eee2ebe1ff53a3cbdbbb73e"
+jest-runtime@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-21.3.0-beta.3.tgz#7aa061223ef5f83f135c9ad01424c979be262f99"
   dependencies:
-    babel-core "^6.0.0"
-    babel-jest "^21.2.0"
-    babel-plugin-istanbul "^4.0.0"
+    babel-jest "21.3.0-beta.3"
+    babel-plugin-istanbul "^4.1.5"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
     graceful-fs "^4.1.11"
-    jest-config "^21.2.1"
-    jest-haste-map "^21.2.0"
+    jest-config "21.3.0-beta.3"
+    jest-haste-map "21.3.0-beta.3"
     jest-regex-util "^21.2.0"
-    jest-resolve "^21.2.0"
-    jest-util "^21.2.1"
+    jest-resolve "21.3.0-beta.3"
+    jest-util "21.3.0-beta.3"
     json-stable-stringify "^1.0.1"
     micromatch "^2.3.11"
     slash "^1.0.0"
@@ -3077,43 +3130,43 @@ jest-runtime@^21.2.1:
     write-file-atomic "^2.1.0"
     yargs "^9.0.0"
 
-jest-snapshot@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-21.2.1.tgz#29e49f16202416e47343e757e5eff948c07fd7b0"
+jest-snapshot@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-21.3.0-beta.3.tgz#bd2d1f49a6447b952513470f973c3ef5d13dbf8b"
   dependencies:
     chalk "^2.0.1"
-    jest-diff "^21.2.1"
-    jest-matcher-utils "^21.2.1"
+    jest-diff "21.3.0-beta.3"
+    jest-matcher-utils "21.3.0-beta.3"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^21.2.1"
+    pretty-format "21.3.0-beta.3"
 
-jest-util@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-21.2.1.tgz#a274b2f726b0897494d694a6c3d6a61ab819bb78"
+jest-util@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-21.3.0-beta.3.tgz#39145e135a01923576e10d2853ccadc8c435eb80"
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
     graceful-fs "^4.1.11"
-    jest-message-util "^21.2.1"
-    jest-mock "^21.2.0"
-    jest-validate "^21.2.1"
+    jest-message-util "21.3.0-beta.3"
+    jest-mock "21.3.0-beta.3"
+    jest-validate "21.3.0-beta.3"
     mkdirp "^0.5.1"
 
-jest-validate@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
+jest-validate@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.3.0-beta.3.tgz#4ff7cf341c7e434a096c11f881ef9fcaf444f2e8"
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^21.2.0"
+    jest-get-type "21.3.0-beta.3"
     leven "^2.1.0"
-    pretty-format "^21.2.1"
+    pretty-format "21.3.0-beta.3"
 
-jest@^21.1.0:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-21.2.1.tgz#c964e0b47383768a1438e3ccf3c3d470327604e1"
+jest@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-21.3.0-beta.3.tgz#2040faf2ab344a44a9092aa6f951baa7c812727b"
   dependencies:
-    jest-cli "^21.2.1"
+    jest-cli "21.3.0-beta.3"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -3640,7 +3693,7 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-notifier@^5.0.2:
+node-notifier@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
   dependencies:
@@ -3996,9 +4049,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-pretty-format@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+pretty-format@21.3.0-beta.3:
+  version "21.3.0-beta.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.3.0-beta.3.tgz#f52e763ef855a5e0b093fc4af201592e896512f9"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -4466,7 +4519,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -4798,6 +4851,12 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.0.tgz#2018a7ad2bdf8faf2691e5fddab26bed5a2bacab"
+  dependencies:
+    source-map "^0.6.0"
+
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -4808,7 +4867,7 @@ source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@~0.6.1:
+source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -4859,6 +4918,10 @@ sshpk@^1.7.0:
 stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+
+stack-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
 standard-version@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
- Introduce a new Jest environment to run tests in headless Chrome (via [Puppeteer](git push --set-upstream origin fix/haspagebreaks))
- Closes #85