### PR TITLE
New rule to ensure that page break markers have an accessible label

### DIFF
--- a/src/report/axe2ace.js
+++ b/src/report/axe2ace.js
@@ -9,6 +9,7 @@ const winston = require('winston');
 const kbMap = {
   'baseUrl': 'http://kb.daisy.org/publishing/',
   'map': {
+    'pagebreak-label': {url: 'docs/navigation/pagelist.html', 'title': 'Page Breaks'},
     'html-has-lang': {url: 'docs/html/lang.html', title: 'Language'},
     'html-lang-valid': {url: 'docs/html/lang.html', title: 'Language'},
     'valid-lang': {url: 'docs/html/lang.html', title: 'Language'},

--- a/src/scripts/ace-axe.js
+++ b/src/scripts/ace-axe.js
@@ -83,6 +83,20 @@ daisy.ace.run = function(done) {
     }
   };
 
+  window.axe.configure({
+    rules: [
+      {
+        id: 'pagebreak-label',
+        selector: '[*|type~="pagebreak"], [role~="doc-pagebreak"]',
+        any: ['aria-label', 'non-empty-title'],
+        metadata: {
+          description: "Ensure page markers have an accessible label",
+        },
+        tags: ['cat.epub']
+      }
+    ]
+  });
+
   window.axe.run(
     {
       "rules": {

--- a/tests/__tests__/axe-rules.test.js
+++ b/tests/__tests__/axe-rules.test.js
@@ -45,3 +45,28 @@ test('DPUB ARIA roles are allowed', async () => {
   const report = await ace('../data/axerule-dpubroles');
   expect(report['earl:result']['earl:outcome']).toEqual('pass');
 });
+
+test('Ensure page breaks have labels', async () => {
+  const report = await ace('../data/axerule-pagebreak-label');
+  expect(report['earl:result']['earl:outcome']).toEqual('fail');
+  expect(report.assertions).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      'earl:testSubject': expect.objectContaining({ url: 'content_001.xhtml' }),
+      assertions: [
+        expect.objectContaining({
+          'earl:test': expect.objectContaining({ 'dct:title': 'pagebreak-label' }),
+          'earl:result': expect.objectContaining({
+            'earl:outcome': 'fail',
+            'earl:pointer': expect.objectContaining({ css: ['#p3'] }),
+          }),
+        }),
+        expect.objectContaining({
+          'earl:test': expect.objectContaining({ 'dct:title': 'pagebreak-label' }),
+          'earl:result': expect.objectContaining({
+            'earl:outcome': 'fail',
+            'earl:pointer': expect.objectContaining({ css: ['#p4'] }),
+          }),
+        }),
+      ],
+    })]));
+});

--- a/tests/data/axerule-dpubroles/EPUB/content_001.xhtml
+++ b/tests/data/axerule-dpubroles/EPUB/content_001.xhtml
@@ -42,7 +42,7 @@
 <div role="doc-introduction"></div>
 <div role="doc-noteref"></div>
 <div role="doc-notice"></div>
-<div role="doc-pagebreak"></div>
+<div role="doc-pagebreak" title="p1"></div>
 <div role="doc-pagelist"></div>
 <div role="doc-part"></div>
 <div role="doc-preface"></div>

--- a/tests/data/axerule-pagebreak-label/EPUB/content_001.xhtml
+++ b/tests/data/axerule-pagebreak-label/EPUB/content_001.xhtml
@@ -1,0 +1,13 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal EPUB</title>
+</head>
+<body>
+<h1>Loomings</h1>
+<p>Call me Ishmael.</p>
+<span id="p1" role="doc-pagebreak" title="p1"/>
+<span id="p2" epub:type="pagebreak" title="p2"/>
+<span id="p3" role="doc-pagebreak"/>
+<span id="p4" epub:type="pagebreak"/>
+</body>
+</html>

--- a/tests/data/axerule-pagebreak-label/EPUB/nav.xhtml
+++ b/tests/data/axerule-pagebreak-label/EPUB/nav.xhtml
@@ -1,0 +1,20 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal Nav</title>
+</head>
+<body>
+<nav epub:type="toc">
+<ol>
+<li><a href="content_001.xhtml">content 001</a></li>
+</ol>
+</nav>
+<nav epub:type="page-list">
+<ol>
+<li><a href="content_001.xhtml#p1">page 1</a></li>
+<li><a href="content_001.xhtml#p2">page 2</a></li>
+<li><a href="content_001.xhtml#p3">page 3</a></li>
+<li><a href="content_001.xhtml#p4">page 4</a></li>
+</ol>
+</nav>
+</body>
+</html>

--- a/tests/data/axerule-pagebreak-label/EPUB/package.opf
+++ b/tests/data/axerule-pagebreak-label/EPUB/package.opf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="uid">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="uid">NOID</dc:identifier>
+  <dc:source>https://example.com</dc:source>
+  <meta property="dcterms:modified">2017-01-01T00:00:01Z</meta>
+  <meta property="schema:accessibilityFeature">structuralNavigation</meta>
+  <meta property="schema:accessibilitySummary">everything OK!</meta>
+  <meta property="schema:accessibilityHazard">noFlashingHazard</meta>
+  <meta property="schema:accessibilityHazard">noSoundHazard</meta>
+  <meta property="schema:accessibilityHazard">noMotionSimulationHazard</meta>
+  <meta property="schema:accessMode">textual</meta>
+  <meta property="schema:accessModeSufficient">textual</meta>
+</metadata>
+<manifest>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/tests/data/axerule-pagebreak-label/META-INF/container.xml
+++ b/tests/data/axerule-pagebreak-label/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   <rootfiles>
+      <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+   </rootfiles>
+</container>

--- a/tests/data/axerule-pagebreak-label/mimetype
+++ b/tests/data/axerule-pagebreak-label/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip


### PR DESCRIPTION
Configure a new aXe rule to ensure that page break markers (identified with the ARIA
role `doc-pagebreak` or with `epub:type="pagebreak"`) have an accessible label defined
in a `title` attribute or an `aria-label` attribute.

Closes #71