### PR TITLE
fix(outlines): only use headings text content in the outline

### DIFF
--- a/packages/ace-core/src/scripts/ace-extraction.js
+++ b/packages/ace-core/src/scripts/ace-extraction.js
@@ -137,7 +137,7 @@ ace.getHeadings = function() {
 
   hxElems.forEach(function(hx) {
     headings.push({
-      html: hx.innerHTML,
+      html: hx.textContent,
       level: +hx.localName.slice(1)
     });
   });

--- a/packages/ace-core/src/scripts/ace-extraction.test.js
+++ b/packages/ace-core/src/scripts/ace-extraction.test.js
@@ -194,6 +194,13 @@ describe('extracting headings', () => {
     expect(results[0].html).toBe('title 1');
     expect(results[0].level).toBe(1);
   });
+
+  test('complex h1', async () => {
+    const results = await run('getHeadings', '<h1>title 1 <a href="#foo">link</a></h1>');
+    expect(results.length).toBe(1);
+    expect(results[0].html).toBe('title 1 link');
+    expect(results[0].level).toBe(1);
+  });
 });
 
 describe('extracting iframes', () => {


### PR DESCRIPTION
The headings extraction script now returns the elements `textContent` property
instead of their `innerHTML`.

A smarter processing could be devised in a future version:
- detect an empty content and report a dummy text
- trim long content

Fixes #129