### PR TITLE
feat(rule): check that epub:type have matching ARIA roles

### DIFF
--- a/packages/ace-core/src/scripts/ace-axe.js
+++ b/packages/ace-core/src/scripts/ace-axe.js
@@ -84,6 +84,82 @@ daisy.ace.run = function(done) {
   };
 
   window.axe.configure({
+    checks: [
+      {
+        id: "matching-aria-role",
+        evaluate: function evaluate(node, options) {
+          var mappings = new Map([
+            ['abstract', 'doc-abstract'],
+            ['acknowledgments', 'doc-acknowledgments'],
+            ['afterword', 'doc-afterword'],
+            ['appendix', 'doc-appendix'],
+            ['backlink', 'doc-backlink'],
+            ['biblioentry', 'doc-biblioentry'],
+            ['bibliography', 'doc-bibliography'],
+            ['biblioref', 'doc-biblioref'],
+            ['chapter', 'doc-chapter'],
+            ['colophon', 'doc-colophon'],
+            ['conclusion', 'doc-conclusion'],
+            ['cover', 'doc-cover'],
+            ['credit', 'doc-credit'],
+            ['credits', 'doc-credits'],
+            ['dedication', 'doc-dedication'],
+            ['endnote', 'doc-endnote'],
+            ['endnotes', 'doc-endnotes'],
+            ['epigraph', 'doc-epigraph'],
+            ['epilogue', 'doc-epilogue'],
+            ['errata', 'doc-errata'],
+            ['footnote', 'doc-footnote'],
+            ['foreword', 'doc-foreword'],
+            ['glossary', 'doc-glossary'],
+            ['glossdef', 'definition'],
+            ['glossref', 'doc-glossref'],
+            ['glossterm', 'term'],
+            ['help', 'doc-tip'],
+            ['index', 'doc-index'],
+            ['introduction', 'doc-introduction'],
+            ['noteref', 'doc-noteref'],
+            ['notice', 'doc-notice'],
+            ['pagebreak', 'doc-pagebreak'],
+            ['page-list', 'doc-pagelist'],
+            ['part', 'doc-part'],
+            ['preface', 'doc-preface'],
+            ['prologue', 'doc-prologue'],
+            ['pullquote', 'doc-pullquote'],
+            ['qna', 'doc-qna'],
+            ['referrer', 'doc-backlink'],
+            ['subtitle', 'doc-subtitle'],
+            ['tip', 'doc-tip'],
+            ['toc', 'doc-toc']
+          ]);
+          if (node.hasAttributeNS('http://www.idpf.org/2007/ops', 'type')) {
+            var type = node.getAttributeNS('http://www.idpf.org/2007/ops', 'type').trim();
+            if (mappings.has(type)) {
+              if (!node.hasAttribute('role')) {
+                return false;
+              } else {
+                var role = node.getAttribute('role').trim();
+                return role == mappings.get(type);
+              }
+            }
+          }
+          return true;
+        },
+        metadata: {
+          impact: 'minor',
+          messages: {
+            pass: function anonymous(it) {
+              var out = 'Element has an ARIA role matching its epub:type';
+              return out;
+            },
+            fail: function anonymous(it) {
+              var out = 'Element has no ARIA role matching its epub:type';
+              return out;
+            }
+          }
+        }
+      }
+    ],
     rules: [
       {
         id: 'pagebreak-label',
@@ -93,6 +169,15 @@ daisy.ace.run = function(done) {
           description: "Ensure page markers have an accessible label",
         },
         tags: ['cat.epub']
+      },
+      {
+        id: 'epub-type-has-matching-role',
+        selector: '[*|type]',
+        any: ['matching-aria-role'],
+        metadata: {
+          description: "Ensure the element has an ARIA role matching its epub:type",
+        },
+        tags: ['best-practice']
       }
     ]
   });

--- a/packages/ace-report/src/generate-html-report.js
+++ b/packages/ace-report/src/generate-html-report.js
@@ -30,6 +30,7 @@ module.exports = function generateHtmlReport(reportData) {
         'wcag2a': 'WCAG 2.0 A',
         'wcag2aa': 'WCAG 2.0 AA',
         'EPUB': 'EPUB',
+        'best-practice': 'Best Practice',
         'other': 'Other'
       };
       violationFilters[rule].forEach(function(value) {
@@ -59,12 +60,13 @@ module.exports = function generateHtmlReport(reportData) {
 
 // summarize the violation ruleset and impact data
 function collectViolationStats(flatListOfViolations) {
-  var rulesetTags = ['wcag2a', 'wcag2aa', 'EPUB'];
+  var rulesetTags = ['wcag2a', 'wcag2aa', 'EPUB', 'best-practice'];
 
   var summaryData = {
     'wcag2a': {'critical': 0, 'serious': 0, 'moderate': 0, 'minor': 0, 'total': 0},
     'wcag2aa': {'critical': 0, 'serious': 0, 'moderate': 0, 'minor': 0, 'total': 0},
     'EPUB': {'critical': 0, 'serious': 0, 'moderate': 0, 'minor': 0, 'total': 0},
+    'best-practice': {'critical': 0, 'serious': 0, 'moderate': 0, 'minor': 0, 'total': 0},
     'other': {'critical': 0, 'serious': 0, 'moderate': 0, 'minor': 0, 'total': 0},
     'total': {'critical': 0, 'serious': 0, 'moderate': 0, 'minor': 0, 'total': 0}
   };
@@ -88,6 +90,7 @@ function collectViolationStats(flatListOfViolations) {
     summaryData['total'][key] += summaryData['wcag2a'][key]
       + summaryData['wcag2aa'][key]
       + summaryData['EPUB'][key]
+      + summaryData['best-practice'][key]
       + summaryData['other'][key];
   });
 
@@ -117,7 +120,7 @@ function createViolationFilters(violations) {
 // we're using 'assertion' and 'violation' somewhat interchangeably
 function createFlatListOfViolations(violations) {
   var flatData = [];
-  var rulesetTags = ['wcag2a', 'wcag2aa', 'EPUB']; // applicable ruleset tags
+  var rulesetTags = ['wcag2a', 'wcag2aa', 'EPUB', 'best-practice']; // applicable ruleset tags
 
   violations.forEach(function(assertion) {
     var filename = assertion["earl:testSubject"]["url"];

--- a/packages/ace-report/src/resources/report-template.handlebars
+++ b/packages/ace-report/src/resources/report-template.handlebars
@@ -214,6 +214,10 @@
             {{#violation_stats "EPUB"}}{{/violation_stats}}
           </tr>
           <tr>
+            <th scope="row">Best Practice</th>
+            {{#violation_stats "best-practice"}}{{/violation_stats}}
+          </tr>
+          <tr>
             <th scope="row">Other</th>
             {{#violation_stats "other"}}{{/violation_stats}}
           </tr>
@@ -425,6 +429,7 @@
       'wcag2a': 'WCAG 2.0 A',
       'wcag2aa': 'WCAG 2.0 AA',
       'EPUB': 'EPUB',
+      'best-practice': 'Best Practice',
       'other': 'Other'
     };
 

--- a/tests/__tests__/axe-rules.test.js
+++ b/tests/__tests__/axe-rules.test.js
@@ -36,6 +36,14 @@ function ace(epub, options = {}) {
     .catch(err => console.log(err));
 }
 
+function findAssertionsForDoc(report, path) {
+  for (const assertion of report.assertions) {
+    if(assertion['earl:testSubject'].url === path) {
+      return assertion.assertions;
+    }
+  }
+}
+
 test('`bypass` rule is disabled', async () => {
   const report = await ace('../data/axerule-bypass');
   expect(report['earl:result']['earl:outcome']).toEqual('pass');
@@ -49,24 +57,90 @@ test('DPUB ARIA roles are allowed', async () => {
 test('Ensure page breaks have labels', async () => {
   const report = await ace('../data/axerule-pagebreak-label');
   expect(report['earl:result']['earl:outcome']).toEqual('fail');
-  expect(report.assertions).toEqual(expect.arrayContaining([
+  const assertions = findAssertionsForDoc(report, 'content_001.xhtml');
+  expect(assertions).toBeDefined();
+  expect(assertions).toEqual(expect.arrayContaining([
     expect.objectContaining({
-      'earl:testSubject': expect.objectContaining({ url: 'content_001.xhtml' }),
-      assertions: [
-        expect.objectContaining({
-          'earl:test': expect.objectContaining({ 'dct:title': 'pagebreak-label' }),
-          'earl:result': expect.objectContaining({
-            'earl:outcome': 'fail',
-            'earl:pointer': expect.objectContaining({ css: ['#p3'] }),
-          }),
-        }),
-        expect.objectContaining({
-          'earl:test': expect.objectContaining({ 'dct:title': 'pagebreak-label' }),
-          'earl:result': expect.objectContaining({
-            'earl:outcome': 'fail',
-            'earl:pointer': expect.objectContaining({ css: ['#p4'] }),
-          }),
-        }),
-      ],
-    })]));
+      'earl:test': expect.objectContaining({ 'dct:title': 'pagebreak-label' }),
+      'earl:result': expect.objectContaining({
+        'earl:outcome': 'fail',
+        'earl:pointer': expect.objectContaining({ css: ['#p3'] }),
+      }),
+    }),
+    expect.objectContaining({
+      'earl:test': expect.objectContaining({ 'dct:title': 'pagebreak-label' }),
+      'earl:result': expect.objectContaining({
+        'earl:outcome': 'fail',
+        'earl:pointer': expect.objectContaining({ css: ['#p4'] }),
+      }),
+    }),
+  ]));
+  expect(assertions).not.toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      'earl:test': expect.objectContaining({ 'dct:title': 'pagebreak-label' }),
+      'earl:result': expect.objectContaining({
+        'earl:outcome': 'fail',
+        'earl:pointer': expect.objectContaining({ css: ['#p1'] }),
+      }),
+    })
+  ]));
+  expect(assertions).not.toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      'earl:test': expect.objectContaining({ 'dct:title': 'pagebreak-label' }),
+      'earl:result': expect.objectContaining({
+        'earl:outcome': 'fail',
+        'earl:pointer': expect.objectContaining({ css: ['#p2'] }),
+      }),
+    })
+  ]));
+});
+
+test('Checks that `epub:type` have matching ARIA roles', async() => {
+  const report = await ace('../data/axerule-matching-dpub-role');
+  expect(report['earl:result']['earl:outcome']).toEqual('fail');
+  const assertions = findAssertionsForDoc(report, 'content_001.xhtml');
+  expect(assertions).toBeDefined();
+  expect(assertions).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      'earl:test': expect.objectContaining({ 'dct:title': 'epub-type-has-matching-role' }),
+      'earl:result': expect.objectContaining({
+        'earl:outcome': 'fail',
+        'earl:pointer': expect.objectContaining({ css: ['#fail1'] }),
+      }),
+    }),
+    expect.objectContaining({
+      'earl:test': expect.objectContaining({ 'dct:title': 'epub-type-has-matching-role' }),
+      'earl:result': expect.objectContaining({
+        'earl:outcome': 'fail',
+        'earl:pointer': expect.objectContaining({ css: ['#fail2'] }),
+      }),
+    }),
+  ]));
+  expect(assertions).not.toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      'earl:test': expect.objectContaining({ 'dct:title': 'epub-type-has-matching-role' }),
+      'earl:result': expect.objectContaining({
+        'earl:outcome': 'fail',
+        'earl:pointer': expect.objectContaining({ css: ['#pass1'] }),
+      }),
+    })
+  ]));
+  expect(assertions).not.toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      'earl:test': expect.objectContaining({ 'dct:title': 'epub-type-has-matching-role' }),
+      'earl:result': expect.objectContaining({
+        'earl:outcome': 'fail',
+        'earl:pointer': expect.objectContaining({ css: ['#pass2'] }),
+      }),
+    })
+  ]));
+  expect(assertions).not.toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      'earl:test': expect.objectContaining({ 'dct:title': 'epub-type-has-matching-role' }),
+      'earl:result': expect.objectContaining({
+        'earl:outcome': 'fail',
+        'earl:pointer': expect.objectContaining({ css: ['#pass3'] }),
+      }),
+    })
+  ]));
 });

--- a/tests/__tests__/regression.test.js
+++ b/tests/__tests__/regression.test.js
@@ -53,7 +53,6 @@ test('issue #57: Failed to execute \'matches\' on \'Element\': \'m:annotation-xm
 
 test('issue #85: failed to detect page markers from `epub:type`', async () => {
   const report = await ace('../data/issue-85');
-  expect(report['earl:result']['earl:outcome']).toEqual('pass');
   expect(report.properties.hasPageBreaks).toBe(true);
 });
 

--- a/tests/data/axerule-matching-dpub-role/EPUB/content_001.xhtml
+++ b/tests/data/axerule-matching-dpub-role/EPUB/content_001.xhtml
@@ -1,0 +1,25 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal EPUB</title>
+</head>
+<body>
+<h1>Loomings</h1>
+<p>Call me Ishmael.</p>
+
+<!-- Passes: -->
+<!-- pass #1: non-epub type -->
+<ol id="pass1" type="1">
+    <li>item 1</li>
+</ol>
+<!-- pass #2: type has matching role -->
+<div id="pass2" epub:type="notice" role="doc-notice">notice</div>
+<!-- pass #3: type has no defined matching role -->
+<div id="pass3" epub:type="bridgehead">hello</div>
+
+<!-- Fails: -->
+<!-- fail #1: missing role -->
+<div id="fail1" epub:type="notice">notice</div>
+<!-- fail #2: non-matching role -->
+<div id="fail2" epub:type="notice" role="doc-tip">notice</div>
+</body>
+</html>

--- a/tests/data/axerule-matching-dpub-role/EPUB/nav.xhtml
+++ b/tests/data/axerule-matching-dpub-role/EPUB/nav.xhtml
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal Nav</title>
+</head>
+<body>
+<nav epub:type="toc" role="doc-toc">
+<ol>
+<li><a href="content_001.xhtml">content 001</a></li>
+</ol>
+</nav>
+</body>
+</html>

--- a/tests/data/axerule-matching-dpub-role/EPUB/package.opf
+++ b/tests/data/axerule-matching-dpub-role/EPUB/package.opf
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="uid">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="uid">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-01-01T00:00:01Z</meta>
+  <meta property="schema:accessibilityFeature">structuralNavigation</meta>
+  <meta property="schema:accessibilitySummary">everything OK!</meta>
+  <meta property="schema:accessibilityHazard">noFlashingHazard</meta>
+  <meta property="schema:accessibilityHazard">noSoundHazard</meta>
+  <meta property="schema:accessibilityHazard">noMotionSimulationHazard</meta>
+  <meta property="schema:accessMode">textual</meta>
+  <meta property="schema:accessModeSufficient">textual</meta>
+</metadata>
+<manifest>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/tests/data/axerule-matching-dpub-role/META-INF/container.xml
+++ b/tests/data/axerule-matching-dpub-role/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   <rootfiles>
+      <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+   </rootfiles>
+</container>

--- a/tests/data/axerule-matching-dpub-role/mimetype
+++ b/tests/data/axerule-matching-dpub-role/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/tests/data/epubrules-pagelist/EPUB/content_001.xhtml
+++ b/tests/data/epubrules-pagelist/EPUB/content_001.xhtml
@@ -5,6 +5,6 @@
 <body>
 <h1>Loomings</h1>
 <p>Call me Ishmael.</p>
-<span id="p1" epub:type="pagebreak" aria-label="p1"/>
+<span id="p1" epub:type="pagebreak" role="doc-pagebreak" aria-label="p1"/>
 </body>
 </html>


### PR DESCRIPTION
- Add a new rule to check that an element with an `epub:type` also declares the matching ARIA role (if any). Impact is `minor`, and category is `best-practice`
- Tweak the HTML report to include the new `best-practice` category

Fixes #70 