### PR TITLE
Add program return code 2

### DIFF
--- a/packages/ace-cli/src/defaults.json
+++ b/packages/ace-cli/src/defaults.json
@@ -1,0 +1,5 @@
+{
+  "cli": {
+    "return-2-on-validation-error": false
+  }
+}

--- a/packages/ace-cli/src/index.js
+++ b/packages/ace-cli/src/index.js
@@ -8,6 +8,11 @@ const winston = require('winston');
 const logger = require('@daisy/ace-logger');
 const ace = require('@daisy/ace-core');
 
+const { config, paths } = require('@daisy/ace-config');
+const defaults = require('./defaults');
+const cliConfig  = config.get('cli', defaults.cli);
+
+
 const cli = meow(`
   Usage: ace [options] <input>
 
@@ -91,6 +96,16 @@ ${overrides.map(file => `  - ${file}`).join('\n')}
     verbose: cli.flags.verbose,
     silent: cli.flags.silent,
     jobId: '',
+  })
+  .then((jobData) => {
+    var reportJson = jobData[1];
+    // if there were violations from the validation process, return 2
+    if (cliConfig['return-2-on-validation-error'] &&
+    reportJson['earl:result']['earl:outcome'] === 'fail') {
+      winston.logAndExit('info', 'Closing logs.', () => {
+        process.exit(2);
+      });
+    }
   })
   .catch((err) => {
     if (err && err.message) winston.error(err.message);

--- a/packages/ace-core/src/checker/checker-epub.js
+++ b/packages/ace-core/src/checker/checker-epub.js
@@ -105,7 +105,8 @@ function check(epub, report) {
   // Check page list is sourced
   checkPageSource(assertion, epub);
 
-  report.addAssertions(assertion.build());
+  var builtAssertions = assertion.build();
+  report.addAssertions(builtAssertions);
 
   // Report the Nav Doc
   report.addEPUBNav(epub.navDoc);
@@ -115,6 +116,11 @@ function check(epub, report) {
     hasManifestFallbacks: epub.hasManifestFallbacks,
     hasBindings: epub.hasBindings,
   });
+  
+  winston.info(`- ${epub.packageDoc.src}: ${
+    (builtAssertions.assertions && builtAssertions.assertions.length > 0)
+      ? builtAssertions.assertions.length
+      : 'No'} issues found`);
 
   return Promise.resolve();
 }

--- a/packages/ace-core/src/core/ace.js
+++ b/packages/ace-core/src/core/ace.js
@@ -60,18 +60,20 @@ module.exports = function ace(epubPath, options) {
     .then((report) => {
       if (options.outdir === undefined) {
         report.cleanData();
-        return process.stdout.write(JSON.stringify(report.json, null, '  '));
+        process.stdout.write(JSON.stringify(report.json, null, '  '));
+        return report;
       }
       return report.copyData(options.outdir)
       .then(() => report.cleanData())
       .then(() => Promise.all([
           report.saveJson(options.outdir),
           report.saveHtml(options.outdir)
-      ]));
+      ]))
+      .then(() => report);
     })
-    .then(() => {
+    .then((report) => {
       winston.info('Done.');
-      resolve(jobId);
+      resolve([jobId, report.json]);
     })
     .catch((err) => {
       winston.error(`Unexpected error: ${(err.message !== undefined) ? err.message : err}`);

--- a/packages/ace-http/src/index.js
+++ b/packages/ace-http/src/index.js
@@ -149,7 +149,8 @@ function newJob(jobdata) {
 
   // execute the job with Ace
   ace(jobdata.internal.epubPath, {'jobid': jobdata.internal.id, 'outdir': jobdata.internal.outputDir})
-  .then((jobid) => {
+  .then((jobData) => {
+    var jobId = jobData[0];
     var idx = joblist.findIndex(job => job.internal.id === jobid);
     winston.info("Job finished " + joblist[idx].internal.id);
     joblist[idx].public.status = JOBSTATUS.done;

--- a/tests/__tests__/__snapshots__/cli.test.js.snap
+++ b/tests/__tests__/__snapshots__/cli.test.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Running the CLI on an unexisting document should fail 1`] = `
+exports[`Running the CLI on a non-existant document should fail 1`] = `
 "[32minfo[39m:    Closing logs.
 Re-run Ace using the --verbose option to enable full debug logging."
 `;
 
-exports[`Running the CLI on an unexisting document should fail 2`] = `
+exports[`Running the CLI on a non-existant document should fail 2`] = `
 "[31merror[39m:   Couldn’t find EPUB file 'unexisting.epub'
 "
 `;

--- a/tests/__tests__/cli.test.js
+++ b/tests/__tests__/cli.test.js
@@ -12,35 +12,35 @@ describe('Running the CLI', () => {
     expect(stderr.trim()).toMatchSnapshot();
     expect(stdout).toMatchSnapshot();
   });
-  
+
   test('with the -h option should print help', () => {
     const { stdout, stderr, status } = ace(['-h']);
     expect(status).toBe(0);
     expect(stderr).toBe('');
     expect(stdout).toMatchSnapshot();
   });
-  
+
   test('with the -v option should print the version number', () => {
     const { stdout, stderr, status } = ace(['-v']);
     expect(status).toBe(0);
     expect(stderr).toBe('');
     expect(stdout.trim()).toBe(pkg.version);
   });
-  
+
   test('with the --version option should print the version number', () => {
     const { stdout, stderr, status } = ace(['--version']);
     expect(status).toBe(0);
     expect(stderr).toBe('');
     expect(stdout.trim()).toBe(pkg.version);
   });
-  
-  test('on an unexisting document should fail', () => {
+
+  test('on a non-existant document should fail', () => {
     const { stdout, stderr, status } = ace(['unexisting.epub']);
     expect(status).toBe(1);
     expect(stdout.trim()).toMatchSnapshot();
     expect(stderr).toMatchSnapshot();
   });
-  
+
   test('with -o pointing to an existing directory should fail', () => {
     const { stdout, stderr, status } = ace(['-o', 'report', 'foo'], {
       cwd: path.resolve(__dirname, '../data'),
@@ -60,5 +60,12 @@ describe('Running the CLI', () => {
     const res = JSON.parse(stdout);
     expect(res).toMatchObject({ '@type': 'earl:report' });
   });
-});
 
+  /*test('with return-2-on-validation-error set to true should exit with return code 2', () => {
+    // TODO this test won't work until we can specify the CLI option to enable returning 2 on violation(s)
+    const { stdout, stderr, status } = ace(['has-violations'], {
+      cwd: path.resolve(__dirname, '../data')
+    });
+    expect(status).toBe(2);
+  });*/
+});

--- a/tests/data/has-violations/EPUB/content_001.xhtml
+++ b/tests/data/has-violations/EPUB/content_001.xhtml
@@ -1,0 +1,10 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal EPUB with violations</title>
+</head>
+<body>
+<h1>Loomings</h1>
+<p>Call me Ishmael.</p>
+<img src="image_001.jpg" />
+</body>
+</html>

--- a/tests/data/has-violations/EPUB/nav.xhtml
+++ b/tests/data/has-violations/EPUB/nav.xhtml
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal Nav</title>
+</head>
+<body>
+<nav epub:type="toc">
+<ol>
+<li><a href="content_001.xhtml">content 001</a></li>
+</ol>
+</nav>
+</body>
+</html>

--- a/tests/data/has-violations/EPUB/package.opf
+++ b/tests/data/has-violations/EPUB/package.opf
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="uid">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0 with violations</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="uid">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-01-01T00:00:01Z</meta>
+  <meta property="schema:accessibilityFeature">structuralNavigation</meta>
+  <meta property="schema:accessibilitySummary">everything OK!</meta>
+  <meta property="schema:accessibilityHazard">noFlashingHazard</meta>
+  <meta property="schema:accessibilityHazard">noSoundHazard</meta>
+  <meta property="schema:accessibilityHazard">noMotionSimulationHazard</meta>
+  <meta property="schema:accessMode">textual</meta>
+  <meta property="schema:accessModeSufficient">textual</meta>
+</metadata>
+<manifest>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/tests/data/has-violations/META-INF/container.xml
+++ b/tests/data/has-violations/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   <rootfiles>
+      <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+   </rootfiles>
+</container>

--- a/tests/data/has-violations/mimetype
+++ b/tests/data/has-violations/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip


### PR DESCRIPTION
CLI returns 2 if there was a validation error/warning. The report json object is returned by ace(), and the calling function in the CLI can see the results of the validation.

Also output if the package doc had any issues (same as we already do for content docs).

Closes #113.