### PR TITLE
fix(report): remove @path property from iframes and images

### DIFF
--- a/packages/ace-core/src/core/ace.js
+++ b/packages/ace-core/src/core/ace.js
@@ -59,13 +59,15 @@ module.exports = function ace(epubPath, options) {
     // Process the Results
     .then((report) => {
       if (options.outdir === undefined) {
+        report.cleanData();
         return process.stdout.write(JSON.stringify(report.json, null, '  '));
       }
-      return Promise.all([
-        report.copyData(options.outdir),
-        report.saveJson(options.outdir),
-        report.saveHtml(options.outdir),
-      ]);
+      return report.copyData(options.outdir)
+      .then(() => report.cleanData())
+      .then(() => Promise.all([
+          report.saveJson(options.outdir),
+          report.saveHtml(options.outdir)
+      ]));
     })
     .then(() => {
       winston.info('Done.');

--- a/packages/ace-report/src/report-builders.js
+++ b/packages/ace-report/src/report-builders.js
@@ -110,6 +110,12 @@ class ReportBuilder {
   build() {
     return this._json;
   }
+  // run the function on the given item under _json.data
+  cleanData(key, fn) {
+    if (this._json.data.hasOwnProperty(key)) {
+        this._json.data[key] = fn(this._json.data[key]);
+    }
+  }
   setOutdir(outdir) {
     this.outdir = outdir;
     return this;


### PR DESCRIPTION
The json data is scrubbed clean of @path properties after the images are copied. If we aren't storing the report on disk, the json data is scrubbed before it gets written to the console.

I'd rather separate out any data that needs to be copied and not have it stored in the report in the first place, but that would involve some redesign. Maybe a good idea for the future.

Closes #64