### PR TITLE
feat(report): add rules descriptions to the report

### DIFF
--- a/packages/ace-core/src/checker/checker-epub.js
+++ b/packages/ace-core/src/checker/checker-epub.js
@@ -16,7 +16,7 @@ function asString(arrayOrString) {
   return '';
 }
 
-function newViolation({ impact = 'serious', title, testDesc, resDesc, kbPath, kbTitle }) {
+function newViolation({ impact = 'serious', title, testDesc, resDesc, kbPath, kbTitle, ruleDesc }) {
   return new builders.AssertionBuilder()
     .withAssertedBy(ASSERTED_BY)
     .withMode(MODE)
@@ -27,7 +27,8 @@ function newViolation({ impact = 'serious', title, testDesc, resDesc, kbPath, kb
         .withDescription(testDesc)
         .withHelp(
           KB_BASE + kbPath,
-          kbTitle)
+          kbTitle,
+          ruleDesc)
         .withRulesetTags(['EPUB'])
         .build())
     .withResult(
@@ -45,6 +46,7 @@ function newMetadataAssertion(name, impact = 'serious') {
     resDesc: `Add a '${name}' metadata property to the Package Document`,
     kbPath: 'docs/metadata/schema-org.html',
     kbTitle: 'Schema.org Accessibility Metadata',
+    ruleDesc: `Publications must declare the '${name}' metadata`
   });
 }
 
@@ -72,6 +74,7 @@ function checkTitle(assertions, epub) {
       resDesc: 'Add a \'dc:title\' metadata property to the Package Document',
       kbPath: '',
       kbTitle: 'EPUB Title',
+      ruleDesc: 'Publications must have a title',
     }));
   }
 }
@@ -86,6 +89,7 @@ function checkPageSource(assertion, epub) {
       resDesc: 'Add a \'dc:source\' metadata property to the Package Document',
       kbPath: 'docs/navigation/pagelist.html',
       kbTitle: 'Page Navigation',
+      ruleDesc: 'Publications with page breaks must declare the \'dc:source\' metadata',
     }));
   }
 }

--- a/packages/ace-report-axe/src/index.js
+++ b/packages/ace-report-axe/src/index.js
@@ -84,7 +84,7 @@ function  axe2ace(spineItem, axeResults) {
         .withImpact(violation.impact)
         .withTitle(violation.id)
         .withDescription(violation.description)
-        .withHelp(kbURL, kbTitle)
+        .withHelp(kbURL, kbTitle, violation.help)
         .withRulesetTags(violation.tags)
         .build();
       violation.nodes.forEach(node => assertion.withAssertions(

--- a/packages/ace-report/src/report-builders.js
+++ b/packages/ace-report/src/report-builders.js
@@ -215,8 +215,8 @@ class TestBuilder {
     this._json['dct:description'] = description;
     return this;
   }
-  withHelp(url, title) {
-    this._json.help = { url, title };
+  withHelp(url, title, description) {
+    this._json.help = { url, title, description };
     return this;
   }
   withRulesetTags(tags) {

--- a/tests/__tests__/report_json.test.js
+++ b/tests/__tests__/report_json.test.js
@@ -57,6 +57,32 @@ describe('check assertions', () => {
         assertions: [],
       }));
   });
+  test('with violations', async () => {
+    const report = await ace(path.join(__dirname, '../data/has-violations'));
+    expect(report['earl:result']).toBeDefined();
+    expect(report['earl:result']).toEqual({ 'earl:outcome': 'fail' });
+    expect(Array.isArray(report.assertions)).toBe(true);
+    report.assertions.forEach(
+      (assertion) => {
+        expect(assertion.assertions).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            'earl:result': expect.objectContaining({
+              'earl:outcome': 'fail',
+            }),
+            'earl:test': expect.objectContaining({
+              'earl:impact': expect.anything(),
+              'dct:title': expect.anything(),
+              'dct:description': expect.anything(),
+              'help': {
+                'url': expect.anything(),
+                'title': expect.anything(),
+                'description': expect.anything(),
+              }
+            })
+          }),
+        ]));
+      });
+  });
 });
 
 describe('check properties', () => {

--- a/tests/data/has-violations/EPUB/package.opf
+++ b/tests/data/has-violations/EPUB/package.opf
@@ -11,7 +11,7 @@
   <meta property="schema:accessibilityHazard">noSoundHazard</meta>
   <meta property="schema:accessibilityHazard">noMotionSimulationHazard</meta>
   <meta property="schema:accessMode">textual</meta>
-  <meta property="schema:accessModeSufficient">textual</meta>
+  <!-- <meta property="schema:accessModeSufficient">textual</meta> -->
 </metadata>
 <manifest>
   <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>


### PR DESCRIPTION
Short descriptions for rules are added to the report in the `help`
object:

```
"help": {
  "url": "http://kb.daisy.org/publishing/docs/some-help",
  "title": "Topic",
  "description": "Publications must do blahblah"
}
```

Fixes #146 

cc @marisademeglio (to be added to the JSON context?)