### PR TITLE
fix(core): don't crash if a content document has an '.xml' extension

### DIFF
--- a/packages/ace-core/package.json
+++ b/packages/ace-core/package.json
@@ -22,6 +22,7 @@
     "@daisy/epub-utils": "^0.8.0",
     "@daisy/puppeteer-utils": "^0.7.0",
     "axe-core": "~2.6.1",
+    "file-url": "^2.0.2",
     "h5o": "^0.11.3",
     "p-map": "^1.2.0",
     "puppeteer": "^1.0.0",

--- a/packages/ace-core/src/checker/checker-chromium.js
+++ b/packages/ace-core/src/checker/checker-chromium.js
@@ -1,14 +1,18 @@
 'use strict';
 
-const fs = require('fs');
+const fileUrl = require('file-url');
+const fs = require('fs-extra');
 const path = require('path');
 const pMap = require('p-map');
 const puppeteer = require('puppeteer');
 const os = require('os');
+const tmp = require('tmp');
 const winston = require('winston');
 
 const axe2ace = require('@daisy/ace-report-axe');
 const utils = require('@daisy/puppeteer-utils');
+
+tmp.setGracefulCleanup();
 
 const scripts = [
   path.resolve(require.resolve('axe-core'), '../axe.min.js'),
@@ -21,8 +25,22 @@ const scripts = [
 async function checkSingle(spineItem, epub, browser) {
   winston.verbose(`- Processing ${spineItem.relpath}`);
   try {
+    let url = spineItem.url;
+    let ext = path.extname(spineItem.filepath);
+    
+    // File extensions other than 'xhtml' or 'html' are not propertly loaded
+    // by puppeteer, so we copy the file to a new `.xhtml` temp file.
+    if (ext !== 'xhtml' && ext !== 'html') {
+      winston.warn(`Copying document with extension '${ext}' to a temporary '.xhtml' file…`);
+      const tmpdir = tmp.dirSync({ unsafeCleanup: true }).name;
+      const tmpFile = path.join(tmpdir, `${path.basename(spineItem.filepath, ext)}.xhtml`)
+      fs.copySync(spineItem.filepath, tmpFile);
+      url = fileUrl(tmpFile);
+      winston.debug(`checking copied file at ${url}`)
+    }
+    
     const page = await browser.newPage();
-    await page.goto(spineItem.url);
+    await page.goto(url);
     await utils.addScripts(scripts, page);
 
     const results = await page.evaluate(() => new Promise((resolve, reject) => {

--- a/tests/__tests__/regression.test.js
+++ b/tests/__tests__/regression.test.js
@@ -65,3 +65,8 @@ test('issue #114: Description list item does not have a <dl> parent element', as
   const report = await ace('../data/issue-114');
   expect(report['earl:result']['earl:outcome']).toEqual('pass');
 });
+
+test('issue #122: Failed to check HTML content with `.xml` extension', async () => {
+  const report = await ace('../data/issue-122');
+  expect(report['earl:result']['earl:outcome']).toEqual('pass');
+});

--- a/tests/data/issue-122/EPUB/content_001.xml
+++ b/tests/data/issue-122/EPUB/content_001.xml
@@ -1,0 +1,9 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal EPUB</title>
+</head>
+<body>
+<h1>Loomings</h1>
+<p>Call me Ishmael.</p>
+</body>
+</html>

--- a/tests/data/issue-122/EPUB/content_002.ace
+++ b/tests/data/issue-122/EPUB/content_002.ace
@@ -1,0 +1,9 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal EPUB</title>
+</head>
+<body>
+<h1>Loomings</h1>
+<p>Call me Ishmael.</p>
+</body>
+</html>

--- a/tests/data/issue-122/EPUB/nav.xhtml
+++ b/tests/data/issue-122/EPUB/nav.xhtml
@@ -1,0 +1,13 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal Nav</title>
+</head>
+<body>
+<nav epub:type="toc">
+<ol>
+<li><a href="content_001.xml">content 001</a></li>
+<li><a href="content_002.ace">content 002</a></li>
+</ol>
+</nav>
+</body>
+</html>

--- a/tests/data/issue-122/EPUB/package.opf
+++ b/tests/data/issue-122/EPUB/package.opf
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="uid">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="uid">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-01-01T00:00:01Z</meta>
+  <meta property="schema:accessibilityFeature">structuralNavigation</meta>
+  <meta property="schema:accessibilitySummary">everything OK!</meta>
+  <meta property="schema:accessibilityHazard">noFlashingHazard</meta>
+  <meta property="schema:accessibilityHazard">noSoundHazard</meta>
+  <meta property="schema:accessibilityHazard">noMotionSimulationHazard</meta>
+  <meta property="schema:accessMode">textual</meta>
+  <meta property="schema:accessModeSufficient">textual</meta>
+</metadata>
+<manifest>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="content_001"  href="content_001.xml" media-type="application/xhtml+xml"/>
+  <item id="content_002"  href="content_002.ace" media-type="application/xhtml+xml"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+  <itemref idref="content_002" />
+</spine>
+</package>

--- a/tests/data/issue-122/META-INF/container.xml
+++ b/tests/data/issue-122/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   <rootfiles>
+      <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+   </rootfiles>
+</container>

--- a/tests/data/issue-122/mimetype
+++ b/tests/data/issue-122/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/yarn.lock
+++ b/yarn.lock
@@ -2174,6 +2174,10 @@ file-exists-promise@^1.0.2:
   dependencies:
     es6-promise "^3.1.2"
 
+file-url@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/file-url/-/file-url-2.0.2.tgz#e951784d79095127d3713029ab063f40818ca2ae"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"


### PR DESCRIPTION
Puppeteer won't laod documents with extension `.xml` as XHTML. When
a Content Document’s extension is not `.xhtml` or `.html`, we first
copy the document to a temp `.xhtml` file and before opening it in
Puppeteer.

Fixes #122