### PR TITLE
feat(data): report the presence of SVG Content Documents

### DIFF
--- a/packages/ace-core/src/checker/checker-epub.js
+++ b/packages/ace-core/src/checker/checker-epub.js
@@ -119,6 +119,7 @@ function check(epub, report) {
   report.addProperties({
     hasManifestFallbacks: epub.hasManifestFallbacks,
     hasBindings: epub.hasBindings,
+    hasSVGContentDocuments: epub.hasSVGContentDocuments,
   });
   
   winston.info(`- ${epub.packageDoc.src}: ${

--- a/tests/__tests__/cli.test.js
+++ b/tests/__tests__/cli.test.js
@@ -88,6 +88,14 @@ describe('Running the CLI', () => {
       const log = stripAnsi(stdout);
       expect(/^warn:\s+Copying document with extension/m.test(log)).toBe(true);
     });
+
+    test('when the EPUB contains SVG Content Documents', () => {
+      const { stdout, stderr, status } = ace(['feat-svg'], {
+        cwd: path.resolve(__dirname, '../data'),
+      });
+      const log = stripAnsi(stdout);
+      expect(/^warn:\s+The SVG Content Documents in this EPUB will be ignored\./m.test(log)).toBe(true);
+    });
   });  
 
   /*test('with return-2-on-validation-error set to true should exit with return code 2', () => {

--- a/tests/__tests__/report_json.test.js
+++ b/tests/__tests__/report_json.test.js
@@ -94,6 +94,7 @@ describe('check properties', () => {
       hasMathML: false,
       hasPageBreaks: false,
       hasFormElements: false,
+      hasSVGContentDocuments: false,
     });
   });
 
@@ -129,6 +130,13 @@ describe('check properties', () => {
     const report = await ace(path.join(__dirname, '../data/feat-pagebreaks'));
     expect(report.properties).toMatchObject({
       hasPageBreaks: true,
+    });
+  });
+
+  test('with svg content docs', async () => {
+    const report = await ace(path.join(__dirname, '../data/feat-svg'));
+    expect(report.properties).toMatchObject({
+      hasSVGContentDocuments: true,
     });
   });
 });

--- a/tests/data/feat-svg/EPUB/content_001.svg
+++ b/tests/data/feat-svg/EPUB/content_001.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" width="600px" height="800px" viewBox="0 0 368 581" version="1.1" preserveAspectRatio="xMidYMid meet">
+	<title>SVG doc</title>
+	<desc>Title</desc>
+</svg>

--- a/tests/data/feat-svg/EPUB/content_002.svg
+++ b/tests/data/feat-svg/EPUB/content_002.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" width="600px" height="800px" viewBox="0 0 368 581" version="1.1" preserveAspectRatio="xMidYMid meet">
+	<title>SVG doc</title>
+	<desc>Title</desc>
+</svg>

--- a/tests/data/feat-svg/EPUB/nav.xhtml
+++ b/tests/data/feat-svg/EPUB/nav.xhtml
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal Nav</title>
+</head>
+<body>
+<nav epub:type="toc">
+<ol>
+<li><a href="content_001.svg">content 001</a></li>
+</ol>
+</nav>
+</body>
+</html>

--- a/tests/data/feat-svg/EPUB/package.opf
+++ b/tests/data/feat-svg/EPUB/package.opf
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="uid">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="uid">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-01-01T00:00:01Z</meta>
+  <meta property="schema:accessibilityFeature">structuralNavigation</meta>
+  <meta property="schema:accessibilitySummary">everything OK!</meta>
+  <meta property="schema:accessibilityHazard">noFlashingHazard</meta>
+  <meta property="schema:accessibilityHazard">noSoundHazard</meta>
+  <meta property="schema:accessibilityHazard">noMotionSimulationHazard</meta>
+  <meta property="schema:accessMode">textual</meta>
+  <meta property="schema:accessModeSufficient">textual</meta>
+</metadata>
+<manifest>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="content_001"  href="content_001.svg" media-type="image/svg+xml"/>
+  <item id="content_002"  href="content_002.svg" media-type="image/svg+xml"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+  <itemref idref="content_002" />
+</spine>
+</package>

--- a/tests/data/feat-svg/META-INF/container.xml
+++ b/tests/data/feat-svg/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   <rootfiles>
+      <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+   </rootfiles>
+</container>

--- a/tests/data/feat-svg/mimetype
+++ b/tests/data/feat-svg/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip


### PR DESCRIPTION
When an EPUB has SVG Content Documents, Ace will report them in the
`hasSVGContentDocuments` field of the `properties` section, and will
log a warning saying these documents will be ignored.

Fixes #94.