### PR TITLE
fix (report): add dcterms:conformsTo, fix HTML entities

### DIFF
--- a/packages/ace-report/src/analyze-a11y-metadata.js
+++ b/packages/ace-report/src/analyze-a11y-metadata.js
@@ -21,21 +21,34 @@ const a11yMeta = [
 "schema:accessModeSufficient",
 "schema:accessibilityAPI",
 "schema:accessibilityControl",
-"a11y:certifiedBy"
+"a11y:certifiedBy",
+"dcterms:conformsTo"
 ];
 
 
 module.exports = {
   // each report is content doc level
-  analyze: function(metadata) {
+  analyze: function(metadata, links) {
     winston.info("Analyzing accessibility metadata");
     var results = {"missing": [], "empty": [], "present": []};
     a11yMeta.forEach(function(property) {
-      if (property in metadata) {
+      if (metadata != undefined && property in metadata) {
         if (
           (typeof metadata[property] === 'string' && metadata[property].trim().length > 0)
           ||
           (Array.isArray(metadata[property]) && metadata[property].length > 0)
+          ){
+          results["present"].push(property);
+        }
+        else {
+          results["empty"].push(property);
+        }
+      }
+      else if (links != undefined && property in links) {
+        if (
+          (typeof links[property] === 'string' && links[property].trim().length > 0)
+          ||
+          (Array.isArray(links[property]) && links[property].length > 0)
           ){
           results["present"].push(property);
         }

--- a/packages/ace-report/src/generate-html-report.js
+++ b/packages/ace-report/src/generate-html-report.js
@@ -22,7 +22,7 @@ module.exports = function generateHtmlReport(reportData) {
 
     // return 5 data cells for each ruleset: critical, serious, moderate, minor, total
     // a ruleset can be "wcag2a", "wcag2aa", "EPUB", "other", or "total" (all rulesets)
-    handlebars.registerHelper('violation_stats', function(rule, options) {
+    handlebars.registerHelper('violationStats', function(rule, options) {
       var str = "<td>" + violationStats[rule]['critical'] + "</td>"
                 + "<td>" + violationStats[rule]['serious'] + "</td>"
                 + "<td>" + violationStats[rule]['moderate'] + "</td>"
@@ -32,7 +32,7 @@ module.exports = function generateHtmlReport(reportData) {
     });
 
     // return a list of <option> elements containing the possible filters for given rule
-    handlebars.registerHelper('violation_filter', function(rule, options) {
+    handlebars.registerHelper('violationFilter', function(rule, options) {
       var filterOptions = "";
       violationFilters[rule].forEach(function(value) {
         // use nicer labels for ruleset options
@@ -48,7 +48,7 @@ module.exports = function generateHtmlReport(reportData) {
 
     // return a stringified json object representing a flat list of violations
     handlebars.registerHelper('violationsJson', function(options) {
-      return new handlebars.SafeString(JSON.stringify(flatListOfViolations) + ";")
+      return new handlebars.SafeString(unescape(JSON.stringify(flatListOfViolations)) + ";")
     });
 
     handlebars.registerHelper('violationRows', function(options) {
@@ -89,11 +89,24 @@ module.exports = function generateHtmlReport(reportData) {
       return new handlebars.SafeString(htmlStr);
     });
 
+    handlebars.registerHelper('insertConformsToRow', function(options) {
+      if (reportData['earl:testSubject'].hasOwnProperty('links') &&
+          reportData['earl:testSubject']['links'].hasOwnProperty('dcterms:conformsTo')) {
+            var conformsTo = reportData['earl:testSubject']['links']['dcterms:conformsTo'];
+        return new handlebars.SafeString(`<tr><td>dcterms:conformsTo</td>
+          <td><a href="${conformsTo}" target="_blank">${conformsTo}</a></td></tr>`);
+      }
+      else {
+        return new handlebars.SafeString('');
+      }
+    });
+
     const content = fs.readFileSync(path.join(__dirname, "./report-template.handlebars")).toString();
     var template = handlebars.compile(content);
     var result = template(reportData);
     resolve(result);
   });
+
 };
 
 // summarize the violation ruleset and impact data

--- a/packages/ace-report/src/report-template.handlebars
+++ b/packages/ace-report/src/report-template.handlebars
@@ -237,27 +237,27 @@
         <tbody>
           <tr>
             <th scope="row">WCAG 2.0 A</th>
-            {{#violation_stats "wcag2a"}}{{/violation_stats}}
+            {{#violationStats "wcag2a"}}{{/violationStats}}
           </tr>
           <tr>
             <th scope="row">WCAG 2.0 AA</th>
-            {{#violation_stats "wcag2aa"}}{{/violation_stats}}
+            {{#violationStats "wcag2aa"}}{{/violationStats}}
           </tr>
           <tr>
             <th scope="row">EPUB</th>
-            {{#violation_stats "EPUB"}}{{/violation_stats}}
+            {{#violationStats "EPUB"}}{{/violationStats}}
           </tr>
           <tr>
             <th scope="row">Best Practice</th>
-            {{#violation_stats "best-practice"}}{{/violation_stats}}
+            {{#violationStats "best-practice"}}{{/violationStats}}
           </tr>
           <tr>
             <th scope="row">Other</th>
-            {{#violation_stats "other"}}{{/violation_stats}}
+            {{#violationStats "other"}}{{/violationStats}}
           </tr>
           <tr>
             <th scope="row">Total</th>
-            {{#violation_stats "total"}}{{/violation_stats}}
+            {{#violationStats "total"}}{{/violationStats}}
           </tr>
         </tbody>
       </table>
@@ -268,22 +268,22 @@
         <span class="filter-label">impact</span>
         <select name="impact" aria-label="impact">
           <option value="all" selected>All</option>
-          {{#violation_filter "impact"}}{{/violation_filter}}
+          {{#violationFilter "impact"}}{{/violationFilter}}
         </select>
         <span class="filter-label">ruleset</span>
         <select name="ruleset" aria-label="ruleset">
           <option value="all" selected>All</option>
-          {{#violation_filter "ruleset"}}{{/violation_filter}}
+          {{#violationFilter "ruleset"}}{{/violationFilter}}
         </select>
         <span class="filter-label">rule</span>
         <select name="rule" aria-label="rule">
           <option value="all" selected>All</option>
-          {{#violation_filter "rule"}}{{/violation_filter}}
+          {{#violationFilter "rule"}}{{/violationFilter}}
         </select>
         <span class="filter-label">file</span>
         <select name="file" aria-label="file">
           <option value="all" selected>All</option>
-          {{#violation_filter "file"}}{{/violation_filter}}
+          {{#violationFilter "file"}}{{/violationFilter}}
         </select>
         <a href="#" onclick="resetFilters()" class="ml-4">Reset filters</a>
       </div>
@@ -329,6 +329,9 @@
             <td>{{this}}</td>
           </tr>
           {{/each}}
+          {{!-- handlebars was complaining about an #if statement here so it was replaced with a helper --}}
+          {{!-- dcterms:conformsTo is a special case metadata item (actually it lives in the links section) --}}
+          {{#insertConformsToRow}}{{/insertConformsToRow}}
         </tbody>
       </table>
 
@@ -518,7 +521,7 @@
       detailsArr.forEach(function(item) {
         if (item != "") {
           var elm = $("<li></li>");
-          elm.text(item);
+          elm.text(decodeEntities(item));
           ul.append(elm);
         }
       });
@@ -579,6 +582,26 @@
       });
     });
     filterSelected();
+  }
+
+  function decodeEntities(text) {
+    // The entities tend to appear in violation descriptions, and there are just a few named ones involved
+    var namedEntities = {
+      "&lt;": "<",
+      "&gt;": ">",
+      "&quot;": "\"",
+      "&nbsp": " "
+    };
+    // process entities
+    var str = text.replace(/&#(\d+);/g, function(match, dec) {
+      return String.fromCharCode(dec);
+		});
+
+    //process named entities
+    Object.keys(namedEntities).forEach(k => {
+      str = str.replace(new RegExp(k, 'g'), namedEntities[k]);
+    });
+    return str;
   }
 
   // certain classes need to be added to elements if we're using javascript in the browser

--- a/packages/ace-report/src/report.js
+++ b/packages/ace-report/src/report.js
@@ -43,7 +43,7 @@ module.exports = class Report {
     this._builder = new builders.ReportBuilder()
       .setOutdir(outdir)
       .withTestSubject(epub.path, '', '', epub.metadata, epub.links)
-      .withA11yMeta(a11yMetaChecker.analyze(epub.metadata))
+      .withA11yMeta(a11yMetaChecker.analyze(epub.metadata, epub.links))
   }
 
   get json() {


### PR DESCRIPTION
The report includes dcterms:conformsTo in the metadata table and reports it as missing if it is not present.

The report also shows HTML entities correctly.

Some report helper functions have more consistent naming too.

Fixes #161
Fixes #171