### PR TITLE
fix(parser): parse HTML named character references

### DIFF
--- a/packages/epub-utils/package.json
+++ b/packages/epub-utils/package.json
@@ -21,7 +21,7 @@
     "fs-extra": "^6.0.1",
     "tmp": "^0.0.33",
     "winston": "^2.4.0",
-    "xmldom": "^0.1.27",
+    "xmldom-alpha": "https://github.com/fchasen/xmldom.git#a38f7ddb536ab74e9fb549477ba9f9b7ea2d0beb",
     "xpath": "^0.0.24"
   },
   "publishConfig": {

--- a/tests/__tests__/cli.test.js
+++ b/tests/__tests__/cli.test.js
@@ -96,7 +96,17 @@ describe('Running the CLI', () => {
       const log = stripAnsi(stdout);
       expect(/^warn:\s+The SVG Content Documents in this EPUB will be ignored\./m.test(log)).toBe(true);
     });
-  });  
+  });
+
+  describe('does not raise a warning', () => {
+    test('when a named character reference is used in XHTML', () => {
+      const { stdout, stderr, status } = ace(['issue-182'], {
+        cwd: path.resolve(__dirname, '../data'),
+      });
+      const log = stripAnsi(stdout);
+      expect(/^warn:\s+\[xmldom error\]	entity not found/m.test(log)).toBe(false);
+    });
+  });
 
   /*test('with return-2-on-validation-error set to true should exit with return code 2', () => {
     // TODO this test won't work until we can specify the CLI option to enable returning 2 on violation(s)

--- a/tests/__tests__/regression.test.js
+++ b/tests/__tests__/regression.test.js
@@ -75,3 +75,15 @@ test('issue #170: heading with `doc-subtitle` role were reported empty', async (
   const report = await ace('../data/issue-170');
   expect(report['earl:result']['earl:outcome']).toEqual('pass');
 });
+
+test('issue #182: named character references are parsed', async () => {
+  const report = await ace('../data/issue-182');
+  expect(report.assertions).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      "earl:testSubject": {
+        "url": "content_001.xhtml",
+        "dct:title": "Minimal – EPUB"
+      }
+    })
+  ]));
+});

--- a/tests/data/issue-182/EPUB/content_001.xhtml
+++ b/tests/data/issue-182/EPUB/content_001.xhtml
@@ -1,0 +1,10 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal &ndash; EPUB</title>
+</head>
+<body>
+<h1>Loomings</h1>
+<p>Call me Ishmael.</p>
+</body>
+</html>

--- a/tests/data/issue-182/EPUB/nav.xhtml
+++ b/tests/data/issue-182/EPUB/nav.xhtml
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+<title>Minimal Nav</title>
+</head>
+<body>
+<nav epub:type="toc">
+<ol>
+<li><a href="content_001.xhtml">content 001</a></li>
+</ol>
+</nav>
+</body>
+</html>

--- a/tests/data/issue-182/EPUB/package.opf
+++ b/tests/data/issue-182/EPUB/package.opf
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="uid">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="uid">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-01-01T00:00:01Z</meta>
+  <meta property="schema:accessibilityFeature">structuralNavigation</meta>
+  <meta property="schema:accessibilitySummary">everything OK!</meta>
+  <meta property="schema:accessibilityHazard">noFlashingHazard</meta>
+  <meta property="schema:accessibilityHazard">noSoundHazard</meta>
+  <meta property="schema:accessibilityHazard">noMotionSimulationHazard</meta>
+  <meta property="schema:accessMode">textual</meta>
+  <meta property="schema:accessModeSufficient">textual</meta>
+</metadata>
+<manifest>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/tests/data/issue-182/META-INF/container.xml
+++ b/tests/data/issue-182/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   <rootfiles>
+      <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+   </rootfiles>
+</container>

--- a/tests/data/issue-182/mimetype
+++ b/tests/data/issue-182/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/yarn.lock
+++ b/yarn.lock
@@ -6080,9 +6080,9 @@ xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
 
-xmldom@^0.1.27:
-  version "0.1.27"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
+"xmldom-alpha@https://github.com/fchasen/xmldom.git#a38f7ddb536ab74e9fb549477ba9f9b7ea2d0beb":
+  version "0.1.28"
+  resolved "https://github.com/fchasen/xmldom.git#a38f7ddb536ab74e9fb549477ba9f9b7ea2d0beb"
 
 xpath@^0.0.24:
   version "0.0.24"


### PR DESCRIPTION
- Use @fchasen’s fork of xmldom to parse the HTML named character
  references defined in HTML, even when the document is XHTML.
  Note however that this is a willful violation of the HTML standard,
  since the entities are only declared when the document has one of the
  allowed public identifiers
  (see https://html.spec.whatwg.org/#parsing-xhtml-documents)
- Set an error handler to xmldom’s `DOMParser` to catch parsing errors
  (like undeclared entities) and log them with winston.
- Add tests.

Fixes #182