### PR TITLE
fix: when img copy fails, keep going

### DIFF
--- a/packages/ace-report/src/report.js
+++ b/packages/ace-report/src/report.js
@@ -110,9 +110,12 @@ module.exports = class Report {
               return fs.pathExists(fromPath)
                 .then((exists) => {
                   if (exists) {
-                    return fs.copy(fromPath, toPath, { overwrite: false });
+                    return fs.copy(fromPath, toPath, { overwrite: false })
+                    .catch(err => {
+                      winston.warn(`Couldn't copy resource '${img.src}'. Error: ${err}`);
+                    });
                   }
-                  winston.warn(`Couldn’t copy resource '${img.src}'`);
+                  winston.warn(`Couldn’t copy resource '${img.src}'. File does not exist.`);
                   return Promise.resolve();
                 });
             }));


### PR DESCRIPTION
Addresses #192 but we still need to find out why the image fails to copy in the first place.