### PR TITLE
docs: Fix "axe" branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ace is a tool to run automated accessibility checks for EPUB Publications, in or
 
 It is important to keep in mind that only a limited portion of accessibility checks can be automated, and therefore __Ace is just a helper tool to assist in a broader, human-driven, evaluation process__.
 
-Under the hood, Ace currently runs the [aXe engine for automated testing of HTML](https://github.com/dequelabs/axe-core), developed by the good folks at Deque Systems.
+Under the hood, Ace currently runs the [axe engine for automated testing of HTML](https://github.com/dequelabs/axe-core), developed by the good folks at Deque Systems.
 
 ## Getting started
 

--- a/packages/ace-report-axe/README.md
+++ b/packages/ace-report-axe/README.md
@@ -1,6 +1,6 @@
 # `ace-report-axe`
 
-[aXe](https://github.com/dequelabs/axe-core)-specific reporting utilities for Ace.
+[axe](https://github.com/dequelabs/axe-core)-specific reporting utilities for Ace.
 
 ## What is Ace?
 

--- a/website/content/contributing/notes.md
+++ b/website/content/contributing/notes.md
@@ -5,7 +5,7 @@ weight = 3
 
 ## HTML checker
 
-Under the hood, most of the HTML checks are powered by [aXe](https://github.com/dequelabs/axe-core), an engine for automated testing of HTML from [Deque Systems](https://www.deque.com/).
+Under the hood, most of the HTML checks are powered by [axe](https://github.com/dequelabs/axe-core), an engine for automated testing of HTML from [Deque Systems](https://www.deque.com/).
 
 ## Headless browser
 


### PR DESCRIPTION
We (Deque) have stopped capitalizing the "x" in our `axe-core` tool. If applied, this patch will correct the casing used here.