### PR TITLE
fix: detect role=heading for outline

### DIFF
--- a/packages/ace-core/src/scripts/ace-extraction.js
+++ b/packages/ace-core/src/scripts/ace-extraction.js
@@ -127,7 +127,7 @@ ace.getHTMLOutline = function() {
 }
 
 ace.getHeadings = function() {
-  let hxElems = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
+  let hxElems = document.querySelectorAll('h1, h2, h3, h4, h5, h6, [role="heading"]');
   let headings = [];
   // FIXME filter headings in sectioning roots
   // function findSectioningRoot (el, cls) {
@@ -136,9 +136,12 @@ ace.getHeadings = function() {
   // }
 
   hxElems.forEach(function(hx) {
+    let level = +hx.localName.slice(1);
+    if (Number.isNaN(level)) level = hx.getAttribute('aria-level');
+    if (Number.isNaN(level)) level = 2; // NOTE aria-level fallback value per ARIA spec
     headings.push({
       html: hx.textContent,
-      level: +hx.localName.slice(1)
+      level: level
     });
   });
 

--- a/packages/ace-core/src/scripts/ace-extraction.js
+++ b/packages/ace-core/src/scripts/ace-extraction.js
@@ -138,7 +138,7 @@ ace.getHeadings = function() {
   hxElems.forEach(function(hx) {
     let level = +hx.localName.slice(1);
     if (Number.isNaN(level)) level = +hx.getAttribute('aria-level');
-    if (level === 0) level = 2; // NOTE null coerced to 0; aria-level fallback value per ARIA spec is 2
+    if (!Number.isInteger(level) || level < 1) level = 2; // NOTE aria-level fallback value per ARIA spec is 2 (and avoid Infinity)
     headings.push({
       html: hx.textContent,
       level: level

--- a/packages/ace-core/src/scripts/ace-extraction.js
+++ b/packages/ace-core/src/scripts/ace-extraction.js
@@ -137,8 +137,8 @@ ace.getHeadings = function() {
 
   hxElems.forEach(function(hx) {
     let level = +hx.localName.slice(1);
-    if (Number.isNaN(level)) level = hx.getAttribute('aria-level');
-    if (Number.isNaN(level)) level = 2; // NOTE aria-level fallback value per ARIA spec
+    if (Number.isNaN(level)) level = +hx.getAttribute('aria-level');
+    if (level === 0) level = 2; // NOTE null coerced to 0; aria-level fallback value per ARIA spec is 2
     headings.push({
       html: hx.textContent,
       level: level

--- a/packages/ace-core/src/scripts/ace-extraction.test.js
+++ b/packages/ace-core/src/scripts/ace-extraction.test.js
@@ -215,6 +215,20 @@ describe('extracting headings', () => {
     expect(results[0].html).toBe('title 1');
     expect(results[0].level).toBe(2);
   });
+
+  test('role=heading with negative aria-level', async () => {
+    const results = await run('getHeadings', '<div role="heading" aria-level="-1">title 1</div>');
+    expect(results.length).toBe(1);
+    expect(results[0].html).toBe('title 1');
+    expect(results[0].level).toBe(2);
+  });
+
+  test('role=heading with infinite aria-level', async () => {
+    const results = await run('getHeadings', '<div role="heading" aria-level="Infinity">title 1</div>');
+    expect(results.length).toBe(1);
+    expect(results[0].html).toBe('title 1');
+    expect(results[0].level).toBe(2);
+  });
 });
 
 describe('extracting iframes', () => {

--- a/packages/ace-core/src/scripts/ace-extraction.test.js
+++ b/packages/ace-core/src/scripts/ace-extraction.test.js
@@ -201,6 +201,20 @@ describe('extracting headings', () => {
     expect(results[0].html).toBe('title 1 link');
     expect(results[0].level).toBe(1);
   });
+
+  test('role=heading with aria-level', async () => {
+    const results = await run('getHeadings', '<div role="heading" aria-level="1">title 1</div>');
+    expect(results.length).toBe(1);
+    expect(results[0].html).toBe('title 1');
+    expect(results[0].level).toBe(1);
+  });
+
+  test('role=heading without aria-level', async () => {
+    const results = await run('getHeadings', '<div role="heading">title 1</div>');
+    expect(results.length).toBe(1);
+    expect(results[0].html).toBe('title 1');
+    expect(results[0].level).toBe(2);
+  });
 });
 
 describe('extracting iframes', () => {


### PR DESCRIPTION
Enables ace-extraction's getHeadings() to detect headings marked
via role=heading; uses aria-level or the spec fallback.

Fixes #308