### PR TITLE
fix: #331 validation accepts list of more than 2 comma-separated items 

### DIFF
--- a/packages/ace-core/src/checker/checker-epub.js
+++ b/packages/ace-core/src/checker/checker-epub.js
@@ -160,7 +160,7 @@ function checkMetadata(assertions, epub) {
         values = [values]
       }
       // Parse list values
-      values = values.map(value => value.trim().replace(',', ' ').replace(/\s{2,}/g, ' ').split(' '))
+      values = values.map(value => value.trim().replace(/,/g, ' ').replace(/\s{2,}/g, ' ').split(' '))
       values = [].concat(...values);
       // Check metadata values are allowed
       // see https://www.w3.org/wiki/WebSchemas/Accessibility

--- a/tests/data/epubrules-metadata/EPUB/package.opf
+++ b/tests/data/epubrules-metadata/EPUB/package.opf
@@ -13,7 +13,7 @@
   <meta property="schema:accessibilityHazard">noMotionSimulationHazard</meta>
   <!-- Fail #2: bad metadata value -->
   <meta property="schema:accessMode">text</meta>
-  <meta property="schema:accessModeSufficient">visual,textual</meta>
+  <meta property="schema:accessModeSufficient">visual,textual,auditory</meta>
 </metadata>
 <manifest>
   <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>


### PR DESCRIPTION
For example, <opf:meta property="schema:accessModeSufficient">textual,visual,auditory</opf:meta> should now be accepted.

Tested on real data, however, I could not try the proposed change to test data as, even with no changes, "yarn test" for me just produced a message complaining that " [31724]: c:\ws\src\node_file.cc:1337: Assertion `(argc) >= (3)' failed."