### PR TITLE
Remove BACC from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ Several publishers and service providers have integrated Ace in their production
 - Vital Source
 
 Some tools based on Ace are also well worth checking out:
-
-- [BACC](http://bacc.dzb.de/) – the born accessible content checker – developped by the German Central Library for the Blind in Leipzig (DZB). It is a web application backed by Ace, providing a user-friendly graphical user interface, and allowing batch processing of several EPUB files. Available in German and English.
 - [Ace plugin for Sigil](https://www.mobileread.com/forums/showthread.php?t=294678). It allows to run Ace checks directly from the Sigil EPUB editor. Check this [screencast](https://screencast-o-matic.com/watch/cF1hQNb9LX) for a quick demo.
 - [Ace plugin for Calibre](https://www.mobileread.com/forums/showthread.php?t=313848), developed by @thiagoeec. It allows to run Ace checks directly from Calibre, the ebook manager.
 


### PR DESCRIPTION
BACC is no more:
<img width="1463" height="381" alt="image" src="https://github.com/user-attachments/assets/1ed616f2-ffa0-4bac-9dbf-d0b121828d46" />
